### PR TITLE
Add support for WriteBatch

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -272,6 +272,10 @@ extern {
     pub fn rocksdb_iter_get_error(iter: RocksDBIterator,
                                   err: *const *const u8);
     // Write batch
+    pub fn rocksdb_write(db: RocksDBInstance,
+                         writeopts: RocksDBWriteOptions,
+                         batch : RocksDBWriteBatch,
+                         err: *mut i8);
     pub fn rocksdb_writebatch_create() -> RocksDBWriteBatch;
     pub fn rocksdb_writebatch_create_from(rep: *const u8,
                                           size: size_t) -> RocksDBWriteBatch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub use rocksdb::{
     RocksDB,
     RocksDBResult,
     RocksDBVector,
+    Writable,
 };
 pub use rocksdb_options::{
     RocksDBOptions,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub use rocksdb::{
     RocksDB,
     RocksDBResult,
     RocksDBVector,
+    WriteBatch,
     Writable,
 };
 pub use rocksdb_options::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@
 
 extern crate rocksdb;
 extern crate test;
-use rocksdb::{RocksDBOptions, RocksDB, MergeOperands, new_bloom_filter};
+use rocksdb::{RocksDBOptions, RocksDB, MergeOperands, new_bloom_filter, Writable};
 use rocksdb::RocksDBCompactionStyle::RocksDBUniversalCompaction;
 
 fn main() {
@@ -88,7 +88,7 @@ mod tests  {
     use test::Bencher;
     use std::thread::sleep_ms;
 
-    use rocksdb::{RocksDBOptions, RocksDB, MergeOperands, new_bloom_filter};
+    use rocksdb::{RocksDBOptions, RocksDB, MergeOperands, new_bloom_filter, Writable};
     use rocksdb::RocksDBCompactionStyle::RocksDBUniversalCompaction;
 
     fn tuned_for_somebody_elses_disk() -> RocksDB {

--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -21,7 +21,7 @@ use std::ptr;
 use std::slice;
 
 use rocksdb_options::{RocksDBOptions};
-use rocksdb::{RocksDB, RocksDBResult, RocksDBVector};
+use rocksdb::{RocksDB, RocksDBResult, RocksDBVector, Writable};
 
 pub struct MergeOperatorCallback {
     pub name: CString,


### PR DESCRIPTION
I've created a new trait, Writable, which is used to allow the same code to interact directly with the database, or with a WriteBatch. I'm not sure what happens if you insert multiple types of records for the same key into the DB in a single WriteBatch; perhaps that should be forbidden.

You can create a writebatch with `WriteBatch::new()`, and you can write it to the DB using `db::write(batch)`.

This is my first Rust code, so please look at it very carefully--I'm not sure whether I'm correctly freeing the C-allocated writebatch object. If that's being allocated and freed correctly, however, I'm reasonably confident in this implementation.