### PR TITLE
Improve safety of borrow checker with ffi objects

### DIFF
--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -20,7 +20,7 @@ use std::mem;
 use std::ptr;
 use std::slice;
 
-use rocksdb_options::RocksDBOptions;
+use rocksdb_options::Options;
 use rocksdb::RocksDB;
 
 pub struct ComparatorCallback {
@@ -69,11 +69,11 @@ fn test_reverse_compare(a: &[u8], b: &[u8]) -> c_int {
 #[test]
 fn compare_works() {
     let path = "_rust_rocksdb_comparetest";
-    let opts = RocksDBOptions::new();
+    let mut opts = Options::new();
     opts.create_if_missing(true);
     opts.add_comparator("test comparator", test_reverse_compare);
-    let db = RocksDB::open(opts, path).unwrap();
+    let db = RocksDB::open(&opts, path).unwrap();
     // TODO add interesting test
     db.close();
-    assert!(RocksDB::destroy(opts, path).is_ok());
+    assert!(RocksDB::destroy(&opts, path).is_ok());
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -92,14 +92,15 @@ pub enum RocksDBUniversalCompactionStyle {
     rocksdb_total_size_compaction_stop_style   = 1
 }
 
+//TODO audit the use of boolean arguments, b/c I think they need to be u8 instead...
 #[link(name = "rocksdb")]
 extern {
     pub fn rocksdb_options_create() -> RocksDBOptions;
+    pub fn rocksdb_options_destroy(opts: RocksDBOptions);
     pub fn rocksdb_cache_create_lru(capacity: size_t) -> RocksDBCache;
     pub fn rocksdb_cache_destroy(cache: RocksDBCache);
     pub fn rocksdb_block_based_options_create() -> RocksDBBlockBasedTableOptions;
-    pub fn rocksdb_block_based_options_destroy(
-        block_options: RocksDBBlockBasedTableOptions);
+    pub fn rocksdb_block_based_options_destroy(opts: RocksDBBlockBasedTableOptions);
     pub fn rocksdb_block_based_options_set_block_size(
         block_options: RocksDBBlockBasedTableOptions,
         block_size: size_t);
@@ -191,8 +192,26 @@ extern {
                        err: *mut i8);
     pub fn rocksdb_readoptions_create() -> RocksDBReadOptions;
     pub fn rocksdb_readoptions_destroy(readopts: RocksDBReadOptions);
-    pub fn rocksdb_readoptions_set_snapshot(read_opts: RocksDBReadOptions,
-                                            snapshot: RocksDBSnapshot);
+    pub fn rocksdb_readoptions_set_verify_checksums(
+            readopts: RocksDBReadOptions,
+            v: bool);
+    pub fn rocksdb_readoptions_set_fill_cache(
+            readopts: RocksDBReadOptions,
+            v: bool);
+    pub fn rocksdb_readoptions_set_snapshot(
+            readopts: RocksDBReadOptions,
+            snapshot: RocksDBSnapshot); //TODO how do I make this a const ref?
+    pub fn rocksdb_readoptions_set_iterate_upper_bound(
+            readopts: RocksDBReadOptions,
+            k: *const u8,
+            kLen: size_t);
+    pub fn rocksdb_readoptions_set_read_tier(
+            readopts: RocksDBReadOptions,
+            tier: c_int);
+    pub fn rocksdb_readoptions_set_tailing(
+            readopts: RocksDBReadOptions,
+            v: bool);
+
     pub fn rocksdb_get(db: RocksDBInstance,
                        readopts: RocksDBReadOptions,
                        k: *const u8, kLen: size_t,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,8 @@ pub use rocksdb::{
     Writable,
 };
 pub use rocksdb_options::{
-    RocksDBOptions,
+    Options,
+    BlockBasedOptions,
 };
 pub use merge_operator::{
     MergeOperands,

--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -20,7 +20,7 @@ use std::mem;
 use std::ptr;
 use std::slice;
 
-use rocksdb_options::{RocksDBOptions};
+use rocksdb_options::{Options};
 use rocksdb::{RocksDB, RocksDBResult, RocksDBVector, Writable};
 
 pub struct MergeOperatorCallback {
@@ -166,10 +166,10 @@ fn test_provided_merge(new_key: &[u8], existing_val: Option<&[u8]>,
 #[test]
 fn mergetest() {
     let path = "_rust_rocksdb_mergetest";
-    let opts = RocksDBOptions::new();
+    let mut opts = Options::new();
     opts.create_if_missing(true);
     opts.add_merge_operator("test operator", test_provided_merge);
-    let db = RocksDB::open(opts, path).unwrap();
+    let db = RocksDB::open(&opts, path).unwrap();
     let p = db.put(b"k1", b"a");
     assert!(p.is_ok());
     db.merge(b"k1", b"b");
@@ -189,10 +189,10 @@ fn mergetest() {
       .on_error( |e| { println!("error reading value")}); //: {", e) });
 
     assert!(m.is_ok());
-    let r: RocksDBResult<RocksDBVector, &str> = db.get(b"k1");
+    let r: RocksDBResult<RocksDBVector, String> = db.get(b"k1");
     assert!(r.unwrap().to_utf8().unwrap() == "abcdefgh");
     assert!(db.delete(b"k1").is_ok());
     assert!(db.get(b"k1").is_none());
     db.close();
-    assert!(RocksDB::destroy(opts, path).is_ok());
+    assert!(RocksDB::destroy(&opts, path).is_ok());
 }

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -23,37 +23,91 @@ use merge_operator::{self, MergeOperatorCallback, MergeOperands, full_merge_call
               partial_merge_callback};
 use comparator::{self, ComparatorCallback, compare_callback};
 
-#[derive(Copy, Clone)]
-pub struct RocksDBOptions {
-    pub inner: rocksdb_ffi::RocksDBOptions,
-    block_options: rocksdb_ffi::RocksDBBlockBasedTableOptions,
+pub struct BlockBasedOptions {
+    inner: rocksdb_ffi::RocksDBBlockBasedTableOptions,
 }
 
-impl RocksDBOptions {
-    pub fn new() -> RocksDBOptions {
+pub struct Options {
+    pub inner: rocksdb_ffi::RocksDBOptions,
+}
+
+impl Drop for Options {
+    fn drop(&mut self) {
+        unsafe {
+            rocksdb_ffi::rocksdb_options_destroy(self.inner);
+        }
+    }
+}
+
+impl Drop for BlockBasedOptions {
+    fn drop(&mut self) {
+        unsafe {
+            rocksdb_ffi::rocksdb_block_based_options_destroy(self.inner);
+        }
+    }
+}
+
+impl BlockBasedOptions {
+    pub fn new() -> BlockBasedOptions {
+        let block_opts = unsafe {rocksdb_ffi::rocksdb_block_based_options_create() };
+        let rocksdb_ffi::RocksDBBlockBasedTableOptions(opt_ptr) = block_opts;
+        if opt_ptr.is_null() {
+            panic!("Could not create rocksdb block based options".to_string());
+        }
+        BlockBasedOptions{ inner: block_opts, }
+    }
+
+    pub fn set_block_size(&mut self, size: u64) {
+        unsafe {
+            rocksdb_ffi::rocksdb_block_based_options_set_block_size(
+                self.inner, size);
+        }
+    }
+
+    //TODO figure out how to create these in a Rusty way
+    ////pub fn set_filter(&mut self, filter: rocksdb_ffi::RocksDBFilterPolicy) {
+    ////    unsafe {
+    ////        rocksdb_ffi::rocksdb_block_based_options_set_filter_policy(
+    ////            self.inner, filter);
+    ////    }
+    ////}
+
+    ////pub fn set_cache(&mut self, cache: rocksdb_ffi::RocksDBCache) {
+    ////    unsafe {
+    ////        rocksdb_ffi::rocksdb_block_based_options_set_block_cache(
+    ////            self.inner, cache);
+    ////    }
+    ////}
+
+    ////pub fn set_cache_compressed(&mut self, cache: rocksdb_ffi::RocksDBCache) {
+    ////    unsafe {
+    ////        rocksdb_ffi::rocksdb_block_based_options_set_block_cache_compressed(
+    ////            self.inner, cache);
+    ////    }
+    ////}
+
+}
+
+impl Options {
+    pub fn new() -> Options {
         unsafe {
             let opts = rocksdb_ffi::rocksdb_options_create();
             let rocksdb_ffi::RocksDBOptions(opt_ptr) = opts;
             if opt_ptr.is_null() {
                 panic!("Could not create rocksdb options".to_string());
             }
-            let block_opts = rocksdb_ffi::rocksdb_block_based_options_create();
-
-            RocksDBOptions{
-                inner: opts,
-                block_options: block_opts,
-            }
+            Options{ inner: opts, }
         }
     }
 
-    pub fn increase_parallelism(&self, parallelism: i32) {
+    pub fn increase_parallelism(&mut self, parallelism: i32) {
         unsafe {
             rocksdb_ffi::rocksdb_options_increase_parallelism(
                 self.inner, parallelism);
         }
     }
 
-    pub fn optimize_level_style_compaction(&self,
+    pub fn optimize_level_style_compaction(&mut self,
         memtable_memory_budget: i32) {
         unsafe {
             rocksdb_ffi::rocksdb_options_optimize_level_style_compaction(
@@ -61,14 +115,14 @@ impl RocksDBOptions {
         }
     }
 
-    pub fn create_if_missing(&self, create_if_missing: bool) {
+    pub fn create_if_missing(&mut self, create_if_missing: bool) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_create_if_missing(
                 self.inner, create_if_missing);
         }
     }
 
-    pub fn add_merge_operator<'a>(&self, name: &str,
+    pub fn add_merge_operator<'a>(&mut self, name: &str,
         merge_fn: fn (&[u8], Option<&[u8]>, &mut MergeOperands) -> Vec<u8>) {
         let cb = Box::new(MergeOperatorCallback {
             name: CString::new(name.as_bytes()).unwrap(),
@@ -87,7 +141,7 @@ impl RocksDBOptions {
         }
     }
 
-    pub fn add_comparator<'a>(&self, name: &str, compare_fn: fn(&[u8], &[u8]) -> i32) {
+    pub fn add_comparator<'a>(&mut self, name: &str, compare_fn: fn(&[u8], &[u8]) -> i32) {
         let cb = Box::new(ComparatorCallback {
             name: CString::new(name.as_bytes()).unwrap(),
             f: compare_fn,
@@ -104,60 +158,20 @@ impl RocksDBOptions {
     }
 
 
-    pub fn set_block_size(&self, size: u64) {
-        unsafe {
-            rocksdb_ffi::rocksdb_block_based_options_set_block_size(
-                self.block_options, size);
-            rocksdb_ffi::rocksdb_options_set_block_based_table_factory(
-                self.inner,
-                self.block_options);
-        }
-    }
-
-    pub fn set_block_cache_size_mb(&self, cache_size: u64) {
+    pub fn set_block_cache_size_mb(&mut self, cache_size: u64) {
         unsafe {
             rocksdb_ffi::rocksdb_options_optimize_for_point_lookup(
                 self.inner, cache_size);
         }
     }
 
-    pub fn set_filter(&self, filter: rocksdb_ffi::RocksDBFilterPolicy) {
-        unsafe {
-            rocksdb_ffi::rocksdb_block_based_options_set_filter_policy(
-                self.block_options, filter);
-            rocksdb_ffi::rocksdb_options_set_block_based_table_factory(
-                self.inner,
-                self.block_options);
-        }
-    }
-
-    pub fn set_cache(&self, cache: rocksdb_ffi::RocksDBCache) {
-        unsafe {
-            rocksdb_ffi::rocksdb_block_based_options_set_block_cache(
-                self.block_options, cache);
-            rocksdb_ffi::rocksdb_options_set_block_based_table_factory(
-                self.inner,
-                self.block_options);
-        }
-    }
-
-    pub fn set_cache_compressed(&self, cache: rocksdb_ffi::RocksDBCache) {
-        unsafe {
-            rocksdb_ffi::rocksdb_block_based_options_set_block_cache_compressed(
-                self.block_options, cache);
-            rocksdb_ffi::rocksdb_options_set_block_based_table_factory(
-                self.inner,
-                self.block_options);
-        }
-    }
-
-    pub fn set_max_open_files(&self, nfiles: c_int) {
+    pub fn set_max_open_files(&mut self, nfiles: c_int) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_max_open_files(self.inner, nfiles);
         }
     }
 
-    pub fn set_use_fsync(&self, useit: bool) {
+    pub fn set_use_fsync(&mut self, useit: bool) {
         unsafe {
             match useit {
                 true =>
@@ -168,14 +182,14 @@ impl RocksDBOptions {
         }
     }
 
-    pub fn set_bytes_per_sync(&self, nbytes: u64) {
+    pub fn set_bytes_per_sync(&mut self, nbytes: u64) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_bytes_per_sync(
                 self.inner, nbytes);
         }
     }
 
-    pub fn set_disable_data_sync(&self, disable: bool) {
+    pub fn set_disable_data_sync(&mut self, disable: bool) {
         unsafe {
             match disable {
                 true =>
@@ -188,63 +202,63 @@ impl RocksDBOptions {
         }
     }
 
-    pub fn set_table_cache_num_shard_bits(&self, nbits: c_int) {
+    pub fn set_table_cache_num_shard_bits(&mut self, nbits: c_int) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_table_cache_numshardbits(
                 self.inner, nbits);
         }
     }
 
-    pub fn set_min_write_buffer_number(&self, nbuf: c_int) {
+    pub fn set_min_write_buffer_number(&mut self, nbuf: c_int) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_min_write_buffer_number_to_merge(
                 self.inner, nbuf);
         }
     }
 
-    pub fn set_max_write_buffer_number(&self, nbuf: c_int) {
+    pub fn set_max_write_buffer_number(&mut self, nbuf: c_int) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_max_write_buffer_number(
                 self.inner, nbuf);
         }
     }
 
-    pub fn set_write_buffer_size(&self, size: size_t) {
+    pub fn set_write_buffer_size(&mut self, size: size_t) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_write_buffer_size(
                 self.inner, size);
         }
     }
 
-    pub fn set_target_file_size_base(&self, size: u64) {
+    pub fn set_target_file_size_base(&mut self, size: u64) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_target_file_size_base(
                 self.inner, size);
         }
     }
 
-    pub fn set_min_write_buffer_number_to_merge(&self, to_merge: c_int) {
+    pub fn set_min_write_buffer_number_to_merge(&mut self, to_merge: c_int) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_min_write_buffer_number_to_merge(
                 self.inner, to_merge);
         }
     }
 
-    pub fn set_level_zero_slowdown_writes_trigger(&self, n: c_int) {
+    pub fn set_level_zero_slowdown_writes_trigger(&mut self, n: c_int) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_level0_slowdown_writes_trigger(
                 self.inner, n);
         }
     }
 
-    pub fn set_level_zero_stop_writes_trigger(&self, n: c_int) {
+    pub fn set_level_zero_stop_writes_trigger(&mut self, n: c_int) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_level0_stop_writes_trigger(
                 self.inner, n);
         }
     }
 
-    pub fn set_compaction_style(&self, style:
+    pub fn set_compaction_style(&mut self, style:
                                 rocksdb_ffi::RocksDBCompactionStyle) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_compaction_style(
@@ -252,28 +266,28 @@ impl RocksDBOptions {
         }
     }
 
-    pub fn set_max_background_compactions(&self, n: c_int) {
+    pub fn set_max_background_compactions(&mut self, n: c_int) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_max_background_compactions(
                 self.inner, n);
         }
     }
 
-    pub fn set_max_background_flushes(&self, n: c_int) {
+    pub fn set_max_background_flushes(&mut self, n: c_int) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_max_background_flushes(
                 self.inner, n);
         }
     }
 
-    pub fn set_filter_deletes(&self, filter: bool) {
+    pub fn set_filter_deletes(&mut self, filter: bool) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_filter_deletes(
                 self.inner, filter);
         }
     }
 
-    pub fn set_disable_auto_compactions(&self, disable: bool) {
+    pub fn set_disable_auto_compactions(&mut self, disable: bool) {
         unsafe {
             match disable {
                 true =>
@@ -283,6 +297,12 @@ impl RocksDBOptions {
                     rocksdb_ffi::rocksdb_options_set_disable_auto_compactions(
                         self.inner, 0),
             }
+        }
+    }
+
+    pub fn set_block_based_table_factory(&mut self, factory: &BlockBasedOptions) {
+        unsafe {
+            rocksdb_ffi::rocksdb_options_set_block_based_table_factory(self.inner, factory.inner);
         }
     }
 }


### PR DESCRIPTION
So, I fixed up the use of borrow and &mut references with the configuration options, with the goal of laying the foundation for exposing the fully configurable read & write APIs, where leaks & API simplicity will be most important.

I started to remove some prefixes from the variables, so that just `use rocksdb` will allow us to write `rocksdb::Options`, `rocksdb::DB`, etc. I hope this is alright; I'll stop doing that if you prefer `use`ing the members of the namespace.