### PR TITLE
Fix boxing problems and add more tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,20 @@
 name = "rocksdb"
 description = "A Rust wrapper for Facebook's RocksDB embeddable database."
 version = "0.0.6"
-authors = ["Tyler Neely <t@jujit.su>"]
+authors = ["Tyler Neely <t@jujit.su>", "David Greenberg <dsg123456789@gmail.com>"]
 license = "Apache-2.0"
+exclude = [
+  ".gitignore",
+  ".travis.yml",
+  "deploy.sh",
+  "test/**/*",
+]
 
 [features]
 default=[]
 valgrind=[]
+
+[[test]]
+
+name = "test"
+path = "test/test.rs"

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,85 +20,35 @@ extern crate test;
 use rocksdb::{Options, RocksDB, MergeOperands, new_bloom_filter, Writable, };
 use rocksdb::RocksDBCompactionStyle::RocksDBUniversalCompaction;
 
-fn snapshot_test() {
-    let path = "_rust_rocksdb_iteratortest";
-    {
-        let mut db = RocksDB::open_default(path).unwrap();
-        let p = db.put(b"k1", b"v1111");
-        assert!(p.is_ok());
-        let p = db.put(b"k2", b"v2222");
-        assert!(p.is_ok());
-        let p = db.put(b"k3", b"v3333");
-        assert!(p.is_ok());
-        let mut snap = db.snapshot();
-        let mut view1 = snap.iterator();
-        println!("See the output of the first iter");
-        for (k,v) in view1.from_start() {
-            println!("Hello {}: {}", std::str::from_utf8(k).unwrap(), std::str::from_utf8(v).unwrap());
-        };
-        for (k,v) in view1.from_start() {
-            println!("Hello {}: {}", std::str::from_utf8(k).unwrap(), std::str::from_utf8(v).unwrap());
-        };
-        for (k,v) in view1.from_end() {
-            println!("Hello {}: {}", std::str::from_utf8(k).unwrap(), std::str::from_utf8(v).unwrap());
-        };
-    }
-    let opts = Options::new();
-    assert!(RocksDB::destroy(&opts, path).is_ok());
-}
-
-fn iterator_test() {
-    let path = "_rust_rocksdb_iteratortest";
-    {
-        let mut db = RocksDB::open_default(path).unwrap();
-        let p = db.put(b"k1", b"v1111");
-        assert!(p.is_ok());
-        let p = db.put(b"k2", b"v2222");
-        assert!(p.is_ok());
-        let p = db.put(b"k3", b"v3333");
-        assert!(p.is_ok());
-        {
-            let mut view1 = db.iterator();
-            println!("See the output of the first iter");
-            for (k,v) in view1.from_start() {
-                println!("Hello {}: {}", std::str::from_utf8(k).unwrap(), std::str::from_utf8(v).unwrap());
-            };
-            for (k,v) in view1.from_start() {
-                println!("Hello {}: {}", std::str::from_utf8(k).unwrap(), std::str::from_utf8(v).unwrap());
-            };
-            for (k,v) in view1.from_end() {
-                println!("Hello {}: {}", std::str::from_utf8(k).unwrap(), std::str::from_utf8(v).unwrap());
-            };
-        }
-        let mut view2 = db.iterator();
-        let p = db.put(b"k4", b"v4444");
-        assert!(p.is_ok());
-        let mut view3 = db.iterator();
-        println!("See the output of the second iter");
-        for (k,v) in view2.from_start() {
-            println!("Hello {}: {}", std::str::from_utf8(k).unwrap(), std::str::from_utf8(v).unwrap());
-        }
-        println!("See the output of the third iter");
-        for (k,v) in view3.from_start() {
-            println!("Hello {}: {}", std::str::from_utf8(k).unwrap(), std::str::from_utf8(v).unwrap());
-        }
-        println!("now the 3rd iter from k2 fwd");
-        for (k,v) in view3.from(b"k2", rocksdb::Direction::forward) {
-            println!("Hello {}: {}", std::str::from_utf8(k).unwrap(), std::str::from_utf8(v).unwrap());
-        }
-        println!("now the 3rd iter from k2 and back");
-        for (k,v) in view3.from(b"k2", rocksdb::Direction::reverse) {
-            println!("Hello {}: {}", std::str::from_utf8(k).unwrap(), std::str::from_utf8(v).unwrap());
-        }
-    }
-    let opts = Options::new();
-    assert!(RocksDB::destroy(&opts, path).is_ok());
-}
+//fn snapshot_test() {
+//    let path = "_rust_rocksdb_iteratortest";
+//    {
+//        let mut db = RocksDB::open_default(path).unwrap();
+//        let p = db.put(b"k1", b"v1111");
+//        assert!(p.is_ok());
+//        let p = db.put(b"k2", b"v2222");
+//        assert!(p.is_ok());
+//        let p = db.put(b"k3", b"v3333");
+//        assert!(p.is_ok());
+//        let mut snap = db.snapshot();
+//        let mut view1 = snap.iterator();
+//        println!("See the output of the first iter");
+//        for (k,v) in view1.from_start() {
+//            println!("Hello {}: {}", std::str::from_utf8(k).unwrap(), std::str::from_utf8(v).unwrap());
+//        };
+//        for (k,v) in view1.from_start() {
+//            println!("Hello {}: {}", std::str::from_utf8(k).unwrap(), std::str::from_utf8(v).unwrap());
+//        };
+//        for (k,v) in view1.from_end() {
+//            println!("Hello {}: {}", std::str::from_utf8(k).unwrap(), std::str::from_utf8(v).unwrap());
+//        };
+//    }
+//    let opts = Options::new();
+//    assert!(RocksDB::destroy(&opts, path).is_ok());
+//}
 
 #[cfg(not(feature = "valgrind"))]
 fn main() {
-    snapshot_test();
-    iterator_test();
     let path = "/tmp/rust-rocksdb";
     let mut db = RocksDB::open_default(path).unwrap();
     assert!(db.put(b"my key", b"my value").is_ok());

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -62,9 +62,9 @@ pub struct SubDBIterator<'a> {
 }
 
 impl <'a> Iterator for SubDBIterator<'a> {
-    type Item = (&'a [u8], &'a [u8]);
+    type Item = (Box<[u8]>, Box<[u8]>);
 
-    fn next(&mut self) -> Option<(&'a[u8], &'a[u8])> {
+    fn next(&mut self) -> Option<(Box<[u8]>, Box<[u8]>)> {
         let native_iter = self.iter.inner;
         if !self.iter.just_seeked {
             match self.direction {
@@ -83,7 +83,8 @@ impl <'a> Iterator for SubDBIterator<'a> {
             let key = unsafe { slice::from_raw_parts(key_ptr, key_len as usize) };
             let val_ptr = unsafe { rocksdb_ffi::rocksdb_iter_value(native_iter, val_len_ptr) };
             let val = unsafe { slice::from_raw_parts(val_ptr, val_len as usize) };
-            Some((key,val))
+
+            Some((key.to_vec().into_boxed_slice(),val.to_vec().into_boxed_slice()))
         } else {
             None
         }
@@ -608,7 +609,7 @@ fn iterator_test() {
         assert!(p.is_ok());
         let mut iter = db.iterator();
         for (k,v) in iter.from_start() {
-            println!("Hello {}: {}", from_utf8(k).unwrap(), from_utf8(v).unwrap());
+            println!("Hello {}: {}", from_utf8(&*k).unwrap(), from_utf8(&*v).unwrap());
         }
     }
     let opts = Options::new();


### PR DESCRIPTION
There's a bug in the lifetime tracking of the iterator before--it turns out that I couldn't figure out how to kill the borrows at the correct time, and you could sometimes read wrong data from the iterator. This patch fixes that by boxing the [u8].