### PR TITLE
More idiomatic iterators?

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //
 pub use ffi as rocksdb_ffi;
 pub use ffi::{DBCompactionStyle, DBComparator, new_bloom_filter};
-pub use rocksdb::{DB, DBIterator, DBVector, Direction, SubDBIterator, Writable, WriteBatch};
+pub use rocksdb::{DB, DBIterator, DBVector, Direction, Writable, WriteBatch, IteratorMode};
 pub use rocksdb_options::{BlockBasedOptions, Options};
 pub use merge_operator::MergeOperands;
 pub mod rocksdb;

--- a/test/test_iterator.rs
+++ b/test/test_iterator.rs
@@ -1,4 +1,4 @@
-use rocksdb::{DB, Direction, Options, Writable};
+use rocksdb::{DB, Direction, Options, Writable, IteratorMode};
 
 fn cba(input: &Box<[u8]>) -> Box<[u8]> {
     input.iter().cloned().collect::<Vec<_>>().into_boxed_slice()
@@ -23,92 +23,90 @@ pub fn test_iterator() {
         assert!(p.is_ok());
         let p = db.put(&*k3, &*v3);
         assert!(p.is_ok());
-        let mut view1 = db.iterator();
         let expected = vec![(cba(&k1), cba(&v1)),
                             (cba(&k2), cba(&v2)),
                             (cba(&k3), cba(&v3))];
         {
-            let iterator1 = view1.from_start();
+            let iterator1 = db.iterator(IteratorMode::Start);
             assert_eq!(iterator1.collect::<Vec<_>>(), expected);
         }
-        // Test that it's reusable a few times
+        // Test that it's idempotent
         {
-            let iterator1 = view1.from_start();
-            assert_eq!(iterator1.collect::<Vec<_>>(), expected);
-        }
-        {
-            let iterator1 = view1.from_start();
+            let iterator1 = db.iterator(IteratorMode::Start);
             assert_eq!(iterator1.collect::<Vec<_>>(), expected);
         }
         {
-            let iterator1 = view1.from_start();
+            let iterator1 = db.iterator(IteratorMode::Start);
+            assert_eq!(iterator1.collect::<Vec<_>>(), expected);
+        }
+        {
+            let iterator1 = db.iterator(IteratorMode::Start);
             assert_eq!(iterator1.collect::<Vec<_>>(), expected);
         }
         // Test it in reverse a few times
         {
-            let iterator1 = view1.from_end();
+            let iterator1 = db.iterator(IteratorMode::End);
             let mut tmp_vec = iterator1.collect::<Vec<_>>();
             tmp_vec.reverse();
             assert_eq!(tmp_vec, expected);
         }
         {
-            let iterator1 = view1.from_end();
+            let iterator1 = db.iterator(IteratorMode::End);
             let mut tmp_vec = iterator1.collect::<Vec<_>>();
             tmp_vec.reverse();
             assert_eq!(tmp_vec, expected);
         }
         {
-            let iterator1 = view1.from_end();
+            let iterator1 = db.iterator(IteratorMode::End);
             let mut tmp_vec = iterator1.collect::<Vec<_>>();
             tmp_vec.reverse();
             assert_eq!(tmp_vec, expected);
         }
         {
-            let iterator1 = view1.from_end();
+            let iterator1 = db.iterator(IteratorMode::End);
             let mut tmp_vec = iterator1.collect::<Vec<_>>();
             tmp_vec.reverse();
             assert_eq!(tmp_vec, expected);
         }
         {
-            let iterator1 = view1.from_end();
+            let iterator1 = db.iterator(IteratorMode::End);
             let mut tmp_vec = iterator1.collect::<Vec<_>>();
             tmp_vec.reverse();
             assert_eq!(tmp_vec, expected);
         }
         // Try it forward again
         {
-            let iterator1 = view1.from_start();
+            let iterator1 = db.iterator(IteratorMode::Start);
             assert_eq!(iterator1.collect::<Vec<_>>(), expected);
         }
         {
-            let iterator1 = view1.from_start();
+            let iterator1 = db.iterator(IteratorMode::Start);
             assert_eq!(iterator1.collect::<Vec<_>>(), expected);
         }
 
+        let old_iterator = db.iterator(IteratorMode::Start);
         let p = db.put(&*k4, &*v4);
         assert!(p.is_ok());
-        let mut view3 = db.iterator();
         let expected2 = vec![(cba(&k1), cba(&v1)),
                              (cba(&k2), cba(&v2)),
                              (cba(&k3), cba(&v3)),
                              (cba(&k4), cba(&v4))];
         {
-            let iterator1 = view1.from_start();
-            assert_eq!(iterator1.collect::<Vec<_>>(), expected);
+            assert_eq!(old_iterator.collect::<Vec<_>>(), expected);
         }
         {
-            let iterator1 = view3.from_start();
+            let iterator1 = db.iterator(IteratorMode::Start);
             assert_eq!(iterator1.collect::<Vec<_>>(), expected2);
         }
         {
-            let iterator1 = view3.from(b"k2", Direction::forward);
+            let iterator1 = db.iterator(IteratorMode::From(b"k2", Direction::forward));
             let expected = vec![(cba(&k2), cba(&v2)),
                                 (cba(&k3), cba(&v3)),
                                 (cba(&k4), cba(&v4))];
             assert_eq!(iterator1.collect::<Vec<_>>(), expected);
         }
         {
-            let iterator1 = view3.from(b"k2", Direction::reverse);
+            let iterator1 = db.iterator(IteratorMode::From(b"k2", Direction::reverse));
             let expected = vec![(cba(&k2), cba(&v2)), (cba(&k1), cba(&v1))];
             assert_eq!(iterator1.collect::<Vec<_>>(), expected);
         }


### PR DESCRIPTION
I had an issue where I wanted to store a reference to a `SubDBIterator` on a struct. Because it's created from a `DBIterator`, I ran into an issue where I couldn't store a reference to both the iterator and sub-iterator on the same struct, and couldn't get the `DBIterator` instance to live long enough (see: https://internals.rust-lang.org/t/self-referencing-structs/418)

This PR merges `SubDBIterator` into `DBIterator`. While I was working on it, I fixed a few todos in the code (the DB lifetime one was also confusing).

I can't think of a better name for the `IteratorMode` enum. Also, I am a rust newb :)