### PR TITLE
Format  codes.

### DIFF
--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -1,4 +1,3 @@
-//
 // Copyright 2014 Tyler Neely
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,4 +1,3 @@
-//
 // Copyright 2014 Tyler Neely
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -101,7 +100,7 @@ pub fn error_message(ptr: *const i8) -> String {
 // TODO audit the use of boolean arguments, b/c I think they need to be u8
 // instead...
 #[link(name = "rocksdb")]
-extern {
+extern "C" {
     pub fn rocksdb_options_create() -> DBOptions;
     pub fn rocksdb_options_destroy(opts: DBOptions);
     pub fn rocksdb_cache_create_lru(capacity: size_t) -> DBCache;
@@ -376,15 +375,17 @@ extern {
     // Comparator
     pub fn rocksdb_options_set_comparator(options: DBOptions,
                                           cb: DBComparator);
-    pub fn rocksdb_comparator_create(
-        state: *mut c_void,
-        destroy: extern fn(*mut c_void) -> (),
-        compare: extern fn (arg: *mut c_void,
-                            a: *const c_char, alen: size_t,
-                            b: *const c_char, blen: size_t
-                           ) -> c_int,
-        name_fn: extern fn(*mut c_void) -> *const c_char
-    ) -> DBComparator;
+    pub fn rocksdb_comparator_create(state: *mut c_void,
+                                     destroy: extern "C" fn(*mut c_void) -> (),
+                                     compare: extern "C" fn(arg: *mut c_void,
+                                                            a: *const c_char,
+                                                            alen: size_t,
+                                                            b: *const c_char,
+                                                            blen: size_t)
+                                                            -> c_int,
+                                     name_fn: extern "C" fn(*mut c_void)
+                                                            -> *const c_char)
+                                     -> DBComparator;
     pub fn rocksdb_comparator_destroy(cmp: DBComparator);
 
     // Column Family

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-//
 // Copyright 2014 Tyler Neely
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +14,8 @@
 //
 pub use ffi as rocksdb_ffi;
 pub use ffi::{DBCompactionStyle, DBComparator, new_bloom_filter};
-pub use rocksdb::{DB, DBIterator, DBVector, Direction, Writable, WriteBatch, IteratorMode};
+pub use rocksdb::{DB, DBIterator, DBVector, Direction, IteratorMode, Writable,
+                  WriteBatch};
 pub use rocksdb_options::{BlockBasedOptions, Options};
 pub use merge_operator::MergeOperands;
 pub mod rocksdb;

--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -1,4 +1,3 @@
-//
 // Copyright 2014 Tyler Neely
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -133,21 +132,19 @@ impl<'a> Iterator for &'a mut MergeOperands {
     fn next(&mut self) -> Option<&'a [u8]> {
         match self.cursor == self.num_operands {
             true => None,
-            false => {
-                unsafe {
-                    let base = self.operands_list as usize;
-                    let base_len = self.operands_list_len as usize;
-                    let spacing = mem::size_of::<*const *const u8>();
-                    let spacing_len = mem::size_of::<*const size_t>();
-                    let len_ptr = (base_len + (spacing_len * self.cursor))
-                        as *const size_t;
-                    let len = *len_ptr as usize;
-                    let ptr = base + (spacing * self.cursor);
-                    self.cursor += 1;
-                    Some(mem::transmute(slice::from_raw_parts(*(ptr as *const *const u8)
+            false => unsafe {
+                let base = self.operands_list as usize;
+                let base_len = self.operands_list_len as usize;
+                let spacing = mem::size_of::<*const *const u8>();
+                let spacing_len = mem::size_of::<*const size_t>();
+                let len_ptr =
+                    (base_len + (spacing_len * self.cursor)) as *const size_t;
+                let len = *len_ptr as usize;
+                let ptr = base + (spacing * self.cursor);
+                self.cursor += 1;
+                Some(mem::transmute(slice::from_raw_parts(*(ptr as *const *const u8)
                         as *const u8, len)))
-                }
-            }
+            },
         }
     }
 
@@ -203,9 +200,7 @@ fn mergetest() {
                     None => println!("did not read valid utf-8 out of the db"),
                 }
             }
-            Err(e) => {
-                println!("error reading value")
-            }
+            Err(e) => println!("error reading value"),
             _ => panic!("value not present"),
         }
 

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1,4 +1,3 @@
-//
 // Copyright 2014 Tyler Neely
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -127,7 +126,10 @@ impl Options {
 
     pub fn add_merge_operator<'a>(&mut self,
                                   name: &str,
-                                  merge_fn: fn(&[u8], Option<&[u8]>, &mut MergeOperands) -> Vec<u8>) {
+                                  merge_fn: fn(&[u8],
+                                               Option<&[u8]>,
+                                               &mut MergeOperands)
+                                               -> Vec<u8>) {
         let cb = Box::new(MergeOperatorCallback {
             name: CString::new(name.as_bytes()).unwrap(),
             merge_fn: merge_fn,
@@ -180,10 +182,12 @@ impl Options {
     pub fn set_use_fsync(&mut self, useit: bool) {
         unsafe {
             match useit {
-                true =>
-                    rocksdb_ffi::rocksdb_options_set_use_fsync(self.inner, 1),
-                false =>
-                    rocksdb_ffi::rocksdb_options_set_use_fsync(self.inner, 0),
+                true => {
+                    rocksdb_ffi::rocksdb_options_set_use_fsync(self.inner, 1)
+                }
+                false => {
+                    rocksdb_ffi::rocksdb_options_set_use_fsync(self.inner, 0)
+                }
             }
         }
     }


### PR DESCRIPTION
Using `rustfmt --write-mode overwrite src/lib.rs` to format. 
