### PR TITLE
export `iterator.valid()`

### DIFF
--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -153,6 +153,10 @@ impl DBIterator {
         }
     }
 
+    pub fn valid(&self) -> bool {
+        unsafe { rocksdb_ffi::rocksdb_iter_valid(self.inner) }
+    }
+
     fn new_cf(db: &DB,
               cf_handle: DBCFHandle,
               readopts: &ReadOptions,

--- a/test/test_iterator.rs
+++ b/test/test_iterator.rs
@@ -112,6 +112,31 @@ pub fn test_iterator() {
             let expected = vec![(cba(&k2), cba(&v2)), (cba(&k1), cba(&v1))];
             assert_eq!(iterator1.collect::<Vec<_>>(), expected);
         }
+        {
+            let iterator1 = db.iterator(IteratorMode::From(b"k0", Direction::Forward));
+            assert!(iterator1.valid());
+            let iterator2 = db.iterator(IteratorMode::From(b"k1", Direction::Forward));
+            assert!(iterator2.valid());
+            let iterator3 = db.iterator(IteratorMode::From(b"k11", Direction::Forward));
+            assert!(iterator3.valid());
+            let iterator4 = db.iterator(IteratorMode::From(b"k5", Direction::Forward));
+            assert!(!iterator4.valid());
+            let iterator5 = db.iterator(IteratorMode::From(b"k0", Direction::Reverse));
+            assert!(iterator5.valid());
+            let iterator6 = db.iterator(IteratorMode::From(b"k1", Direction::Reverse));
+            assert!(iterator6.valid());
+            let iterator7 = db.iterator(IteratorMode::From(b"k11", Direction::Reverse));
+            assert!(iterator7.valid());
+            let iterator8 = db.iterator(IteratorMode::From(b"k5", Direction::Reverse));
+            assert!(!iterator8.valid());
+        }
+        {
+            let mut iterator1 = db.iterator(IteratorMode::From(b"k4", Direction::Forward));
+            iterator1.next();
+            assert!(iterator1.valid());
+            iterator1.next();
+            assert!(!iterator1.valid());
+        }
     }
     let opts = Options::new();
     assert!(DB::destroy(&opts, path).is_ok());


### PR DESCRIPTION
The `valid()` method could be helpful when we want to know if an iterator is positioned at a kv pair after calling `seek()`.