### PR TITLE
Bump libc crate to 0.2.10, audit u64 and usize usage in ffi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ name = "test"
 path = "test/test.rs"
 
 [dependencies]
-libc = "0.1.8"
+libc = "0.2.10"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -162,17 +162,17 @@ extern "C" {
     pub fn rocksdb_options_set_level0_stop_writes_trigger(options: DBOptions,
                                                           no: c_int);
     pub fn rocksdb_options_set_write_buffer_size(options: DBOptions,
-                                                 bytes: u64);
+                                                 bytes: usize);
     pub fn rocksdb_options_set_target_file_size_base(options: DBOptions,
                                                      bytes: u64);
     pub fn rocksdb_options_set_target_file_size_multiplier(options: DBOptions,
                                                            mul: c_int);
     pub fn rocksdb_options_set_max_log_file_size(options: DBOptions,
-                                                 bytes: u64);
+                                                 bytes: usize);
     pub fn rocksdb_options_set_max_manifest_file_size(options: DBOptions,
-                                                      bytes: u64);
+                                                      bytes: usize);
     pub fn rocksdb_options_set_hash_skip_list_rep(options: DBOptions,
-                                                  bytes: u64,
+                                                  bytes: usize,
                                                   a1: i32,
                                                   a2: i32);
     pub fn rocksdb_options_set_compaction_style(options: DBOptions,

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -69,7 +69,7 @@ impl BlockBasedOptions {
         BlockBasedOptions { inner: block_opts }
     }
 
-    pub fn set_block_size(&mut self, size: u64) {
+    pub fn set_block_size(&mut self, size: usize) {
         unsafe {
             rocksdb_ffi::rocksdb_block_based_options_set_block_size(self.inner,
                                                                     size);


### PR DESCRIPTION
@petehunt I've fixed the improper use of u64 in a few places here.  I'd prefer not to use a rocksdb compilation dependency as a few forks do from within this library, because that can be pulled in separately and there is no reason that logic has to live in here.  Let me know if there's anything else that would help in order to get this working for your target!