### PR TITLE
Cherry pick new options methods from ngaut's fork

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -207,6 +207,7 @@ extern "C" {
     pub fn rocksdb_options_set_report_bg_io_stats(options: DBOptions, v: c_int);
     pub fn rocksdb_options_set_wal_recovery_mode(options: DBOptions, mode: DBRecoveryMode);
     pub fn rocksdb_options_enable_statistics(options: DBOptions);
+    pub fn rocksdb_options_statistics_get_string(options: DBOptions) -> *const c_char;
     pub fn rocksdb_options_set_stats_dump_period_sec(options: DBOptions, v: usize);
     pub fn rocksdb_options_set_num_levels(options: DBOptions, v: c_int);
     pub fn rocksdb_filterpolicy_create_bloom_full(bits_per_key: c_int)

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -147,6 +147,7 @@ extern "C" {
     pub fn rocksdb_options_set_bytes_per_sync(options: DBOptions, bytes: u64);
     pub fn rocksdb_options_set_disable_data_sync(options: DBOptions,
                                                  v: c_int);
+    pub fn rocksdb_options_set_allow_os_buffer(options: DBOptions, is_allow: bool);
     pub fn rocksdb_options_optimize_for_point_lookup(options: DBOptions,
                                                      block_cache_size_mb: u64);
     pub fn rocksdb_options_set_table_cache_numshardbits(options: DBOptions,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -208,6 +208,7 @@ extern "C" {
     pub fn rocksdb_options_set_wal_recovery_mode(options: DBOptions, mode: DBRecoveryMode);
     pub fn rocksdb_options_enable_statistics(options: DBOptions);
     pub fn rocksdb_options_set_stats_dump_period_sec(options: DBOptions, v: usize);
+    pub fn rocksdb_options_set_num_levels(options: DBOptions, v: c_int);
     pub fn rocksdb_filterpolicy_create_bloom_full(bits_per_key: c_int)
                                                 -> DBFilterPolicy;
     pub fn rocksdb_filterpolicy_create_bloom(bits_per_key: c_int)

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -178,7 +178,7 @@ extern "C" {
     pub fn rocksdb_options_set_compaction_style(options: DBOptions,
                                                 cs: DBCompactionStyle);
     pub fn rocksdb_options_set_compression(options: DBOptions,
-                                           compression_style_no: c_int);
+                                           compression_style_no: DBCompressionType);
     pub fn rocksdb_options_set_max_background_compactions(
         options: DBOptions, max_bg_compactions: c_int);
     pub fn rocksdb_options_set_max_background_flushes(options: DBOptions,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -167,6 +167,8 @@ extern "C" {
                                                      bytes: u64);
     pub fn rocksdb_options_set_target_file_size_multiplier(options: DBOptions,
                                                            mul: c_int);
+    pub fn rocksdb_options_set_max_bytes_for_level_base(options: DBOptions, bytes: u64);
+    pub fn rocksdb_options_set_max_bytes_for_level_multiplier(options: DBOptions, mul: c_int);
     pub fn rocksdb_options_set_max_log_file_size(options: DBOptions,
                                                  bytes: usize);
     pub fn rocksdb_options_set_max_manifest_file_size(options: DBOptions,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -94,6 +94,15 @@ pub enum DBUniversalCompactionStyle {
     rocksdb_total_size_compaction_stop_style = 1,
 }
 
+#[derive(Copy, Clone, PartialEq)]
+#[repr(C)]
+pub enum DBRecoveryMode {
+    TolerateCorruptedTailRecords = 0,
+    AbsoluteConsistency = 1,
+    PointInTime = 2,
+    SkipAnyCorruptedRecords = 3,
+}
+
 pub fn error_message(ptr: *const i8) -> String {
     let c_str = unsafe { CStr::from_ptr(ptr as *const _) };
     let s = from_utf8(c_str.to_bytes()).unwrap().to_owned();
@@ -196,6 +205,7 @@ extern "C" {
     pub fn rocksdb_options_set_disable_auto_compactions(options: DBOptions,
                                                         v: c_int);
     pub fn rocksdb_options_set_report_bg_io_stats(options: DBOptions, v: c_int);
+    pub fn rocksdb_options_set_wal_recovery_mode(options: DBOptions, mode: DBRecoveryMode);
     pub fn rocksdb_filterpolicy_create_bloom_full(bits_per_key: c_int)
                                                 -> DBFilterPolicy;
     pub fn rocksdb_filterpolicy_create_bloom(bits_per_key: c_int)

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -189,6 +189,7 @@ extern "C" {
     pub fn rocksdb_options_set_filter_deletes(options: DBOptions, v: bool);
     pub fn rocksdb_options_set_disable_auto_compactions(options: DBOptions,
                                                         v: c_int);
+    pub fn rocksdb_options_set_report_bg_io_stats(options: DBOptions, v: c_int);
     pub fn rocksdb_filterpolicy_create_bloom(bits_per_key: c_int)
                                              -> DBFilterPolicy;
     pub fn rocksdb_open(options: DBOptions,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -182,6 +182,9 @@ extern "C" {
                                                 cs: DBCompactionStyle);
     pub fn rocksdb_options_set_compression(options: DBOptions,
                                            compression_style_no: DBCompressionType);
+    pub fn rocksdb_options_set_compression_per_level(options: DBOptions,
+                                            level_values: *const DBCompressionType,
+                                            num_levels: size_t);
     pub fn rocksdb_options_set_max_background_compactions(
         options: DBOptions, max_bg_compactions: c_int);
     pub fn rocksdb_options_set_max_background_flushes(options: DBOptions,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 extern crate libc;
-use self::libc::{c_char, c_int, c_void, size_t};
+use self::libc::{c_char, c_uchar, c_int, c_void, size_t};
 use std::ffi::CStr;
 use std::str::from_utf8;
 
@@ -122,6 +122,8 @@ extern "C" {
     pub fn rocksdb_block_based_options_set_block_restart_interval(
         block_options: DBBlockBasedTableOptions,
         block_restart_interval: c_int);
+    pub fn rocksdb_block_based_options_set_cache_index_and_filter_blocks(
+        block_options: DBBlockBasedTableOptions, v: c_uchar);
     pub fn rocksdb_block_based_options_set_filter_policy(
         block_options: DBBlockBasedTableOptions,
         filter_policy: DBFilterPolicy);
@@ -194,6 +196,8 @@ extern "C" {
     pub fn rocksdb_options_set_disable_auto_compactions(options: DBOptions,
                                                         v: c_int);
     pub fn rocksdb_options_set_report_bg_io_stats(options: DBOptions, v: c_int);
+    pub fn rocksdb_filterpolicy_create_bloom_full(bits_per_key: c_int)
+                                                -> DBFilterPolicy;
     pub fn rocksdb_filterpolicy_create_bloom(bits_per_key: c_int)
                                              -> DBFilterPolicy;
     pub fn rocksdb_open(options: DBOptions,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -206,6 +206,8 @@ extern "C" {
                                                         v: c_int);
     pub fn rocksdb_options_set_report_bg_io_stats(options: DBOptions, v: c_int);
     pub fn rocksdb_options_set_wal_recovery_mode(options: DBOptions, mode: DBRecoveryMode);
+    pub fn rocksdb_options_enable_statistics(options: DBOptions);
+    pub fn rocksdb_options_set_stats_dump_period_sec(options: DBOptions, v: usize);
     pub fn rocksdb_filterpolicy_create_bloom_full(bits_per_key: c_int)
                                                 -> DBFilterPolicy;
     pub fn rocksdb_filterpolicy_create_bloom(bits_per_key: c_int)

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -70,6 +70,7 @@ pub fn new_cache(capacity: size_t) -> DBCache {
     unsafe { rocksdb_cache_create_lru(capacity) }
 }
 
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub enum DBCompressionType {
     None = 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 pub use ffi as rocksdb_ffi;
-pub use ffi::{DBCompactionStyle, DBComparator, DBCompressionType, new_bloom_filter};
+pub use ffi::{DBCompactionStyle, DBComparator, DBCompressionType, DBRecoveryMode, new_bloom_filter};
 pub use rocksdb::{DB, DBIterator, DBVector, Direction, IteratorMode, Writable,
                   WriteBatch};
 pub use rocksdb_options::{BlockBasedOptions, Options, WriteOptions};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 pub use ffi as rocksdb_ffi;
-pub use ffi::{DBCompactionStyle, DBComparator, new_bloom_filter};
+pub use ffi::{DBCompactionStyle, DBComparator, DBCompressionType, new_bloom_filter};
 pub use rocksdb::{DB, DBIterator, DBVector, Direction, IteratorMode, Writable,
                   WriteBatch};
 pub use rocksdb_options::{BlockBasedOptions, Options, WriteOptions};

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -434,6 +434,12 @@ impl DB {
         self.write_opt(batch, &WriteOptions::default())
     }
 
+    pub fn write_withou_wal(&self, batch: WriteBatch) -> Result<(), String> {
+        let mut wo = WriteOptions::new();
+        wo.disable_wal(true);
+        self.write_opt(batch, &wo)
+    }
+
     pub fn get_opt(&self,
                    key: &[u8],
                    readopts: &ReadOptions)

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -270,6 +270,12 @@ impl Options {
         }
     }
 
+    pub fn set_max_manifest_file_size(&mut self, size: usize) {
+        unsafe {
+            rocksdb_ffi::rocksdb_options_set_max_manifest_file_size(self.inner, size);
+        }
+    }
+
     pub fn set_target_file_size_base(&mut self, size: u64) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_target_file_size_base(self.inner,
@@ -404,5 +410,17 @@ impl Default for WriteOptions {
             panic!("Could not create rocksdb write options".to_string());
         }
         WriteOptions { inner: write_opts }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Options;
+
+    #[test]
+    fn test_set_max_manifest_file_size() {
+        let mut opts = Options::default();
+        let size = 20 * 1024 * 1024;
+        opts.set_max_manifest_file_size(size)
     }
 }

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 extern crate libc;
-use self::libc::c_int;
+use self::libc::{c_int,size_t};
 use std::ffi::CString;
 use std::mem;
 
@@ -114,6 +114,14 @@ impl Options {
     pub fn compression(&mut self, t: DBCompressionType) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_compression(self.inner, t);
+        }
+    }
+
+    pub fn compression_per_level(&mut self, level_types: &[DBCompressionType]) {
+        unsafe {
+            rocksdb_ffi::rocksdb_options_set_compression_per_level(self.inner,
+                                                                level_types.as_ptr(),
+                                                                level_types.len() as size_t)
         }
     }
 

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -65,6 +65,15 @@ impl BlockBasedOptions {
                                                                     size);
         }
     }
+
+    pub fn set_lru_cache(&mut self, size: size_t) {
+        let cache = rocksdb_ffi::new_cache(size);
+        unsafe {
+            // because cache is wrapped in shared_ptr, so we don't need to call
+            // rocksdb_cache_destroy explicitly.
+            rocksdb_ffi::rocksdb_block_based_options_set_block_cache(self.inner, cache);
+        }
+    }
 }
 
 impl Default for BlockBasedOptions {

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -372,6 +372,19 @@ impl Options {
             rocksdb_ffi::rocksdb_options_set_wal_recovery_mode(self.inner, mode);
         }
     }
+
+    pub fn enable_statistics(&mut self) {
+        unsafe {
+            rocksdb_ffi::rocksdb_options_enable_statistics(self.inner);
+        }
+    }
+
+    pub fn set_stats_dump_period_sec(&mut self, period: usize) {
+        unsafe {
+            rocksdb_ffi::rocksdb_options_set_stats_dump_period_sec(self.inner,
+                                                      period);
+        }
+    }
 }
 
 impl Default for Options {
@@ -428,5 +441,12 @@ mod tests {
         let mut opts = Options::default();
         let size = 20 * 1024 * 1024;
         opts.set_max_manifest_file_size(size)
+    }
+
+    #[test]
+    fn test_enable_statistics() {
+        let mut opts = Options::default();
+        opts.enable_statistics();
+        opts.set_stats_dump_period_sec(60);
     }
 }

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -195,6 +195,13 @@ impl Options {
         }
     }
 
+    pub fn allow_os_buffer(&mut self, is_allow: bool) {
+        unsafe {
+            rocksdb_ffi::rocksdb_options_set_allow_os_buffer(self.inner,
+                                                             is_allow);
+        }
+    }
+
     pub fn set_table_cache_num_shard_bits(&mut self, nbits: c_int) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_table_cache_numshardbits(self.inner,

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -284,6 +284,13 @@ impl Options {
         }
     }
 
+    pub fn set_level_zero_compaction_trigger(&mut self, n: c_int) {
+        unsafe {
+            rocksdb_ffi::rocksdb_options_set_level0_file_num_compaction_trigger(
+                self.inner, n);
+        }
+    }
+
     pub fn set_level_zero_slowdown_writes_trigger(&mut self, n: c_int) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_level0_slowdown_writes_trigger(

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -385,6 +385,12 @@ impl Options {
                                                       period);
         }
     }
+
+    pub fn set_num_levels(&mut self, n: c_int) {
+        unsafe {
+            rocksdb_ffi::rocksdb_options_set_num_levels(self.inner, n);
+        }
+    }
 }
 
 impl Default for Options {

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -334,9 +334,20 @@ impl WriteOptions {
     pub fn new() -> WriteOptions {
         WriteOptions::default()
     }
+
     pub fn set_sync(&mut self, sync: bool) {
         unsafe {
             rocksdb_ffi::rocksdb_writeoptions_set_sync(self.inner, sync);
+        }
+    }
+
+    pub fn disable_wal(&mut self, disable: bool) {
+        unsafe {
+            if disable {
+                rocksdb_ffi::rocksdb_writeoptions_disable_WAL(self.inner, 1);
+            } else {
+                rocksdb_ffi::rocksdb_writeoptions_disable_WAL(self.inner, 0);
+            }
         }
     }
 }

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -284,7 +284,7 @@ impl Options {
         }
     }
 
-    pub fn set_level_zero_compaction_trigger(&mut self, n: c_int) {
+    pub fn set_level_zero_file_num_compaction_trigger(&mut self, n: c_int) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_level0_file_num_compaction_trigger(
                 self.inner, n);

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -315,6 +315,16 @@ impl Options {
             rocksdb_ffi::rocksdb_options_set_block_based_table_factory(self.inner, factory.inner);
         }
     }
+
+    pub fn set_report_bg_io_stats(&mut self, enable: bool) {
+        unsafe {
+            if enable {
+                rocksdb_ffi::rocksdb_options_set_report_bg_io_stats(self.inner, 1);
+            } else {
+                rocksdb_ffi::rocksdb_options_set_report_bg_io_stats(self.inner, 0);
+            }
+        }
+    }
 }
 
 impl Default for Options {

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -17,7 +17,7 @@ use self::libc::c_int;
 use std::ffi::CString;
 use std::mem;
 
-use rocksdb_ffi;
+use rocksdb_ffi::{self, DBCompressionType};
 use merge_operator::{self, MergeFn, MergeOperatorCallback,
                      full_merge_callback, partial_merge_callback};
 use comparator::{self, ComparatorCallback, compare_callback};
@@ -99,6 +99,12 @@ impl Options {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_create_if_missing(
                 self.inner, create_if_missing);
+        }
+    }
+
+    pub fn compression(&mut self, t: DBCompressionType) {
+        unsafe {
+            rocksdb_ffi::rocksdb_options_set_compression(self.inner, t);
         }
     }
 

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -17,7 +17,7 @@ use self::libc::{c_int,size_t};
 use std::ffi::CString;
 use std::mem;
 
-use rocksdb_ffi::{self, DBCompressionType};
+use rocksdb_ffi::{self, DBCompressionType, DBRecoveryMode};
 use merge_operator::{self, MergeFn, MergeOperatorCallback,
                      full_merge_callback, partial_merge_callback};
 use comparator::{self, ComparatorCallback, compare_callback};
@@ -364,6 +364,12 @@ impl Options {
             } else {
                 rocksdb_ffi::rocksdb_options_set_report_bg_io_stats(self.inner, 0);
             }
+        }
+    }
+
+    pub fn set_wal_recovery_mode(&mut self, mode: DBRecoveryMode) {
+        unsafe {
+            rocksdb_ffi::rocksdb_options_set_wal_recovery_mode(self.inner, mode);
         }
     }
 }

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -74,6 +74,26 @@ impl BlockBasedOptions {
             rocksdb_ffi::rocksdb_block_based_options_set_block_cache(self.inner, cache);
         }
     }
+
+    pub fn set_bloom_filter(&mut self, bits_per_key: c_int, block_based: bool) {
+        unsafe {
+            let bloom = if block_based {
+                rocksdb_ffi::rocksdb_filterpolicy_create_bloom(bits_per_key)
+            } else {
+                rocksdb_ffi::rocksdb_filterpolicy_create_bloom_full(bits_per_key)
+            };
+
+            rocksdb_ffi::rocksdb_block_based_options_set_filter_policy(self.inner,
+                                                                       bloom);
+        }
+    }
+
+    pub fn set_cache_index_and_filter_blocks(&mut self, v: bool) {
+        unsafe {
+            rocksdb_ffi::rocksdb_block_based_options_set_cache_index_and_filter_blocks(self.inner,
+                                                                                       v as u8);
+        }
+    }
 }
 
 impl Default for BlockBasedOptions {

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -214,6 +214,18 @@ impl Options {
         }
     }
 
+    pub fn set_max_bytes_for_level_base(&mut self, size: u64) {
+        unsafe {
+            rocksdb_ffi::rocksdb_options_set_max_bytes_for_level_base(self.inner, size);
+        }
+    }
+
+    pub fn set_max_bytes_for_level_multiplier(&mut self, mul: i32) {
+        unsafe {
+            rocksdb_ffi::rocksdb_options_set_max_bytes_for_level_multiplier(self.inner, mul);
+        }
+    }
+
     pub fn set_target_file_size_base(&mut self, size: u64) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_target_file_size_base(self.inner,

--- a/test/test.rs
+++ b/test/test.rs
@@ -3,3 +3,4 @@ extern crate rocksdb;
 mod test_iterator;
 mod test_multithreaded;
 mod test_column_family;
+mod test_rocksdb_options;

--- a/test/test_rocksdb_options.rs
+++ b/test/test_rocksdb_options.rs
@@ -1,0 +1,12 @@
+use rocksdb::{DB, Options};
+
+
+#[test]
+fn test_set_num_levels() {
+	let path = "_rust_rocksdb_test_set_num_levels";
+	let mut opts = Options::default();
+	opts.create_if_missing(true);
+	opts.set_num_levels(2);
+	let db = DB::open(&opts, path).unwrap();
+	drop(db);
+}


### PR DESCRIPTION
Part of #69

This pull request ports the following changes from @ngaut's fork:

- Add compression option https://github.com/ngaut/rust-rocksdb/pull/8
- Add max_bytes_for_level option https://github.com/ngaut/rust-rocksdb/pull/10
- Add disable_wal option https://github.com/ngaut/rust-rocksdb/pull/11
- Add report_bg_io and compression_per_level options https://github.com/ngaut/rust-rocksdb/pull/19
- Add set_bloom_filter and set_cache_index_and_filter_blocks to BlockBasedOptions https://github.com/ngaut/rust-rocksdb/pull/25
- Add set_level_zero_file_num_compaction_trigger option https://github.com/ngaut/rust-rocksdb/pull/30
- Add set_max_manifest_file_size option https://github.com/ngaut/rust-rocksdb/pull/33
- Add set_wal_recovery_mode option https://github.com/ngaut/rust-rocksdb/pull/34
  - follow up fix: https://github.com/ngaut/rust-rocksdb/pull/36
- Add enable_statistics and set_stats_dump_period_sec options https://github.com/ngaut/rust-rocksdb/pull/42
- Add set_num_levels option https://github.com/ngaut/rust-rocksdb/pull/45
- Add get_statistics option https://github.com/ngaut/rust-rocksdb/pull/49

The following changes will be dealt with separately

**Add set_iterator_upper_bound to ReadOptions https://github.com/ngaut/rust-rocksdb/pull/31**

This changes the ownership of ``ReadOptions`` which we would like to avoid if possible

**Add set_compaction_filter option https://github.com/ngaut/rust-rocksdb/pull/43**

This change is big and porting it would be difficult as it's based on lots of refactoring