### PR TITLE
Added an Error type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 pub use ffi as rocksdb_ffi;
 pub use ffi::{DBCompactionStyle, DBComparator, DBCompressionType, DBRecoveryMode, new_bloom_filter};
 pub use rocksdb::{DB, DBIterator, DBVector, Direction, IteratorMode, Writable,
-                  WriteBatch};
+                  WriteBatch, Error};
 pub use rocksdb_options::{BlockBasedOptions, Options, WriteOptions};
 pub use merge_operator::MergeOperands;
 pub mod rocksdb;

--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -208,7 +208,7 @@ fn mergetest() {
         }
 
         assert!(m.is_ok());
-        let r: Result<Option<DBVector>, String> = db.get(b"k1");
+        let r = db.get(b"k1");
         assert!(r.unwrap().unwrap().to_utf8().unwrap() == "abcdefgh");
         assert!(db.delete(b"k1").is_ok());
         assert!(db.get(b"k1").unwrap().is_none());

--- a/test/test_column_family.rs
+++ b/test/test_column_family.rs
@@ -44,7 +44,7 @@ pub fn test_column_family() {
             families")
             }
             Err(e) => {
-                assert!(e.starts_with("Invalid argument: You have to open \
+                assert!(e.to_string().starts_with("Invalid argument: You have to open \
                                        all column families."))
             }
         }


### PR DESCRIPTION
This makes it easier for people who are using the try!() macro to convert errors into their own Error type. It isn't possible to diffrentiate between errors raised from RocksDB and other string errors at the moment.

This adds a simple ``Error`` type that wraps ``String``. People using RocksDB can now implement ``impl From<rocksdb::Error> for MyError`` and add custom behaviour for handling RocksDB errors.

I've implemented ``From<rocksdb:Error> for String`` and added a ``to_string`` method to the ``Error`` type itself to make it easier for those relying on strings to upgrade.