### PR TITLE
Port path() method from ngauts fork and implement Debug for DB

### DIFF
--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -22,6 +22,7 @@ use std::ops::Deref;
 use std::path::Path;
 use std::slice;
 use std::str::from_utf8;
+use std::fmt;
 
 use self::libc::size_t;
 
@@ -781,6 +782,12 @@ impl Drop for DB {
             }
             rocksdb_ffi::rocksdb_close(self.inner);
         }
+    }
+}
+
+impl fmt::Debug for DB {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "RocksDB {{ path: {:?} }}", self.path())
     }
 }
 

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -31,6 +31,7 @@ use rocksdb_options::{Options, WriteOptions};
 pub struct DB {
     inner: rocksdb_ffi::DBInstance,
     cfs: BTreeMap<String, DBCFHandle>,
+    path: String,
 }
 
 unsafe impl Send for DB {}
@@ -375,6 +376,7 @@ impl DB {
         Ok(DB {
             inner: db,
             cfs: cf_map,
+            path: path.to_owned(),
         })
     }
 
@@ -410,6 +412,10 @@ impl DB {
             return Err(error_message(err));
         }
         Ok(())
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
     }
 
     pub fn write_opt(&self,


### PR DESCRIPTION
Part of #69

This pull request pulls across https://github.com/ngaut/rust-rocksdb/pull/15 which implements a ``path()`` method on ``DB`` that returns the path the ``DB`` was opened with. I've also implemented the ``Debug`` trait for ``DB`` which uses this new method.