### PR TITLE
Add set_iterate_upper_bound method on ReadOptions

### DIFF
--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -886,6 +886,14 @@ impl ReadOptions {
                                                           snapshot.inner);
         }
     }
+
+    pub fn set_iterate_upper_bound(&mut self, key: &[u8]) {
+        unsafe {
+            rocksdb_ffi::rocksdb_readoptions_set_iterate_upper_bound(self.inner,
+                                                                     key.as_ptr(),
+                                                                     key.len() as size_t);
+        }
+    }
 }
 
 impl Default for ReadOptions {


### PR DESCRIPTION
Part of #69

This pull request ports https://github.com/ngaut/rust-rocksdb/pull/31. I've removed the dead code and there is no longer a need to change the ownership of ``ReadOptions``