### PR TITLE
Implement len() and is_empty() methods on WriteBatch

### DIFF
--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -763,6 +763,10 @@ impl WriteBatch {
     pub fn count(&self) -> usize {
         unsafe { rocksdb_ffi::rocksdb_writebatch_count(self.inner) as usize }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.count() == 0
+    }
 }
 
 impl Default for WriteBatch {
@@ -979,8 +983,10 @@ fn writebatch_works() {
             let batch = WriteBatch::default();
             assert!(db.get(b"k1").unwrap().is_none());
             assert_eq!(batch.count(), 0);
+            assert!(batch.is_empty());
             let _ = batch.put(b"k1", b"v1111");
             assert_eq!(batch.count(), 1);
+            assert!(!batch.is_empty());
             assert!(db.get(b"k1").unwrap().is_none());
             let p = db.write(batch);
             assert!(p.is_ok());
@@ -992,6 +998,7 @@ fn writebatch_works() {
             let batch = WriteBatch::default();
             let _ = batch.delete(b"k1");
             assert_eq!(batch.count(), 1);
+            assert!(!batch.is_empty());
             let p = db.write(batch);
             assert!(p.is_ok());
             assert!(db.get(b"k1").unwrap().is_none());

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -760,12 +760,12 @@ impl Writable for DB {
 }
 
 impl WriteBatch {
-    pub fn count(&self) -> usize {
+    pub fn len(&self) -> usize {
         unsafe { rocksdb_ffi::rocksdb_writebatch_count(self.inner) as usize }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.count() == 0
+        self.len() == 0
     }
 }
 
@@ -982,10 +982,10 @@ fn writebatch_works() {
             // test put
             let batch = WriteBatch::default();
             assert!(db.get(b"k1").unwrap().is_none());
-            assert_eq!(batch.count(), 0);
+            assert_eq!(batch.len(), 0);
             assert!(batch.is_empty());
             let _ = batch.put(b"k1", b"v1111");
-            assert_eq!(batch.count(), 1);
+            assert_eq!(batch.len(), 1);
             assert!(!batch.is_empty());
             assert!(db.get(b"k1").unwrap().is_none());
             let p = db.write(batch);
@@ -997,7 +997,7 @@ fn writebatch_works() {
             // test delete
             let batch = WriteBatch::default();
             let _ = batch.delete(b"k1");
-            assert_eq!(batch.count(), 1);
+            assert_eq!(batch.len(), 1);
             assert!(!batch.is_empty());
             let p = db.write(batch);
             assert!(p.is_ok());

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -759,6 +759,12 @@ impl Writable for DB {
     }
 }
 
+impl WriteBatch {
+    pub fn count(&self) -> usize {
+        unsafe { rocksdb_ffi::rocksdb_writebatch_count(self.inner) as usize }
+    }
+}
+
 impl Default for WriteBatch {
     fn default() -> WriteBatch {
         WriteBatch {
@@ -972,7 +978,9 @@ fn writebatch_works() {
             // test put
             let batch = WriteBatch::default();
             assert!(db.get(b"k1").unwrap().is_none());
+            assert_eq!(batch.count(), 0);
             let _ = batch.put(b"k1", b"v1111");
+            assert_eq!(batch.count(), 1);
             assert!(db.get(b"k1").unwrap().is_none());
             let p = db.write(batch);
             assert!(p.is_ok());
@@ -983,6 +991,7 @@ fn writebatch_works() {
             // test delete
             let batch = WriteBatch::default();
             let _ = batch.delete(b"k1");
+            assert_eq!(batch.count(), 1);
             let p = db.write(batch);
             assert!(p.is_ok());
             assert!(db.get(b"k1").unwrap().is_none());


### PR DESCRIPTION
Part of #69

These changes we're ported from https://github.com/ngaut/rust-rocksdb/pull/22.

The original implementation named the ``len()`` method ``count()``. I renamed it to ``len()`` to be more conventional with Rust.

``count()`` in Rust usually means that you have to actually "count" something that you do not know the length of, such as an iterator. ``len()`` in Rust usually means that you already know the length and can return it quickly. Looking at the [RocksDB source code](https://github.com/facebook/rocksdb/blob/2c1f95291d0142957d74042aea14682539085501/db/write_batch.cc#L12), ``count`` is just a value stored in memory so I think it makes sense for it to be named ``len()`` in the Rust API.