### PR TITLE
Improve naming of some of the new Options methods

### DIFF
--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -185,7 +185,7 @@ fn mergetest() {
     let path = "_rust_rocksdb_mergetest";
     let mut opts = Options::default();
     opts.create_if_missing(true);
-    opts.add_merge_operator("test operator", test_provided_merge);
+    opts.set_merge_operator("test operator", test_provided_merge);
     {
         let db = DB::open(&opts, path).unwrap();
         let p = db.put(b"k1", b"a");

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -185,6 +185,13 @@ impl Options {
         }
     }
 
+    #[deprecated(since="0.5.0", note="add_merge_operator has been renamed to set_merge_operator")]
+    pub fn add_merge_operator(&mut self,
+                          name: &str,
+                          merge_fn: MergeFn) {
+        self.set_merge_operator(name, merge_fn);
+    }
+
     /// Sets the comparator used to define the order of keys in the table.
     /// Default: a comparator that uses lexicographic byte-wise ordering
     ///
@@ -207,6 +214,13 @@ impl Options {
                 comparator::name_callback);
             rocksdb_ffi::rocksdb_options_set_comparator(self.inner, cmp);
         }
+    }
+
+    #[deprecated(since="0.5.0", note="add_comparator has been renamed to set_comparator")]
+    pub fn add_comparator(&mut self,
+                          name: &str,
+                          compare_fn: fn(&[u8], &[u8]) -> i32) {
+        self.set_comparator(name, compare_fn);
     }
 
     pub fn optimize_for_point_lookup(&mut self, cache_size: u64) {

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -144,7 +144,7 @@ impl Options {
     /// levels after base level.
     ///
     /// Default: DBCompressionType::None
-    pub fn compression(&mut self, t: DBCompressionType) {
+    pub fn set_compression_type(&mut self, t: DBCompressionType) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_compression(self.inner, t);
         }
@@ -165,7 +165,7 @@ impl Options {
         }
     }
 
-    pub fn add_merge_operator(&mut self,
+    pub fn set_merge_operator(&mut self,
                               name: &str,
                               merge_fn: MergeFn) {
         let cb = Box::new(MergeOperatorCallback {
@@ -191,7 +191,7 @@ impl Options {
     /// The client must ensure that the comparator supplied here has the
     //// same name and orders keys *exactly* the same as the comparator
     /// provided to previous open calls on the same DB.
-    pub fn add_comparator(&mut self,
+    pub fn set_comparator(&mut self,
                           name: &str,
                           compare_fn: fn(&[u8], &[u8]) -> i32) {
         let cb = Box::new(ComparatorCallback {
@@ -209,7 +209,7 @@ impl Options {
         }
     }
 
-    pub fn set_block_cache_size_mb(&mut self, cache_size: u64) {
+    pub fn optimize_for_point_lookup(&mut self, cache_size: u64) {
         unsafe {
             rocksdb_ffi::rocksdb_options_optimize_for_point_lookup(self.inner,
                                                                    cache_size);

--- a/test/test_column_family.rs
+++ b/test/test_column_family.rs
@@ -22,7 +22,7 @@ pub fn test_column_family() {
     {
         let mut opts = Options::default();
         opts.create_if_missing(true);
-        opts.add_merge_operator("test operator", test_provided_merge);
+        opts.set_merge_operator("test operator", test_provided_merge);
         let mut db = DB::open(&opts, path).unwrap();
         let opts = Options::default();
         match db.create_cf("cf1", &opts) {
@@ -36,7 +36,7 @@ pub fn test_column_family() {
     // should fail to open db without specifying same column families
     {
         let mut opts = Options::default();
-        opts.add_merge_operator("test operator", test_provided_merge);
+        opts.set_merge_operator("test operator", test_provided_merge);
         match DB::open(&opts, path) {
             Ok(_) => {
                 panic!("should not have opened DB successfully without \
@@ -53,7 +53,7 @@ pub fn test_column_family() {
     // should properly open db when specyfing all column families
     {
         let mut opts = Options::default();
-        opts.add_merge_operator("test operator", test_provided_merge);
+        opts.set_merge_operator("test operator", test_provided_merge);
         match DB::open_cf(&opts, path, &["cf1"]) {
             Ok(_) => println!("successfully opened db with column family"),
             Err(e) => panic!("failed to open db with column family: {}", e),
@@ -84,7 +84,7 @@ fn test_merge_operator() {
     // TODO should be able to write, read, merge, batch, and iterate over a cf
     {
         let mut opts = Options::default();
-        opts.add_merge_operator("test operator", test_provided_merge);
+        opts.set_merge_operator("test operator", test_provided_merge);
         let db = match DB::open_cf(&opts, path, &["cf1"]) {
             Ok(db) => {
                 println!("successfully opened db with column family");


### PR DESCRIPTION
Part of #69 

None of these methods have been in a past released version so I don't think we need to worry about backwards compatibility.

Changes as follows:
 - Renamed ``compression`` to ``set_compression_type``. I think this is a much clearer name
 - Renamed ``add_merge_operator`` to ``set_merge_operator`` and ``add_comparator`` to ``set_comparator``. Both of these methods replace the entire value of their respective option so "add" is the wrong term to use here.
 - Renamed ``set_block_cache_size_mb`` to ``rocksdb_options_optimize_for_point_lookup``. To match RocksDB's API