### PR TITLE
Remove Options.set_filter_deletes

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -201,7 +201,6 @@ extern "C" {
         options: DBOptions, max_bg_compactions: c_int);
     pub fn rocksdb_options_set_max_background_flushes(options: DBOptions,
                                                       max_bg_flushes: c_int);
-    pub fn rocksdb_options_set_filter_deletes(options: DBOptions, v: bool);
     pub fn rocksdb_options_set_disable_auto_compactions(options: DBOptions,
                                                         v: c_int);
     pub fn rocksdb_options_set_report_bg_io_stats(options: DBOptions, v: c_int);

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -534,12 +534,6 @@ impl Options {
         }
     }
 
-    pub fn set_filter_deletes(&mut self, filter: bool) {
-        unsafe {
-            rocksdb_ffi::rocksdb_options_set_filter_deletes(self.inner, filter);
-        }
-    }
-
     /// Disables automatic compactions. Manual compactions can still
     /// be issued on this column family
     ///


### PR DESCRIPTION
Fixes #79

Deprecated (and removed) as of RocksDB 4.10

https://github.com/facebook/rocksdb/commit/7b79238b655ef6c7ef05c8052c3ded9981c4b54e