### PR TITLE
Make iterator not copy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod rocksdb;
 mod rocksdb_options;
 
 pub use rocksdb::{DB, DBCompactionStyle, DBCompressionType, DBIterator, DBRecoveryMode, DBVector,
-                  Direction, Error, IteratorMode, Snapshot, Writable, WriteBatch, new_bloom_filter};
+                  Direction, Error, IteratorMode, Kv, Snapshot, Writable, WriteBatch, new_bloom_filter};
 pub use merge_operator::MergeOperands;
 
 pub struct BlockBasedOptions {

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -83,7 +83,10 @@ pub struct Snapshot<'a> {
     inner: *const ffi::rocksdb_snapshot_t,
 }
 
-pub struct DBIterator {
+// We need to find a better way to add a lifetime in here.
+#[allow(dead_code)]
+pub struct DBIterator<'a> {
+    db: &'a DB,
     inner: *mut ffi::rocksdb_iterator_t,
     direction: Direction,
     just_seeked: bool,
@@ -94,7 +97,7 @@ pub enum Direction {
     Reverse,
 }
 
-pub type KVBytes = (Box<[u8]>, Box<[u8]>);
+pub type Kv<'a> = (&'a [u8], &'a [u8]);
 
 #[derive(Debug, PartialEq)]
 pub struct Error {
@@ -123,10 +126,10 @@ impl fmt::Display for Error {
     }
 }
 
-impl Iterator for DBIterator {
-    type Item = KVBytes;
+impl<'a> Iterator for DBIterator<'a> {
+    type Item = Kv<'a>;
 
-    fn next(&mut self) -> Option<KVBytes> {
+    fn next(&mut self) -> Option<Kv<'a>> {
         let native_iter = self.inner;
         if !self.just_seeked {
             match self.direction {
@@ -148,7 +151,7 @@ impl Iterator for DBIterator {
                 unsafe { ffi::rocksdb_iter_value(native_iter, val_len_ptr) as *const c_uchar };
             let val = unsafe { slice::from_raw_parts(val_ptr, val_len as usize) };
 
-            Some((key.to_vec().into_boxed_slice(), val.to_vec().into_boxed_slice()))
+            Some((key, val))
         } else {
             None
         }
@@ -161,12 +164,13 @@ pub enum IteratorMode<'a> {
     From(&'a [u8], Direction),
 }
 
-impl DBIterator {
-    fn new(db: &DB, readopts: &ReadOptions, mode: IteratorMode) -> DBIterator {
+impl<'a> DBIterator<'a> {
+    fn new(db: &'a DB, readopts: &ReadOptions, mode: IteratorMode) -> DBIterator<'a> {
         unsafe {
             let iterator = ffi::rocksdb_create_iterator(db.inner, readopts.inner);
 
             let mut rv = DBIterator {
+                db: db,
                 inner: iterator,
                 direction: Direction::Forward, // blown away by set_mode()
                 just_seeked: false,
@@ -202,15 +206,16 @@ impl DBIterator {
         unsafe { ffi::rocksdb_iter_valid(self.inner) != 0 }
     }
 
-    fn new_cf(db: &DB,
+    fn new_cf(db: &'a DB,
               cf_handle: *mut ffi::rocksdb_column_family_handle_t,
               readopts: &ReadOptions,
               mode: IteratorMode)
-              -> Result<DBIterator, Error> {
+              -> Result<DBIterator<'a>, Error> {
         unsafe {
             let iterator = ffi::rocksdb_create_iterator_cf(db.inner, readopts.inner, cf_handle);
 
             let mut rv = DBIterator {
+                db: db,
                 inner: iterator,
                 direction: Direction::Forward, // blown away by set_mode()
                 just_seeked: false,
@@ -221,7 +226,7 @@ impl DBIterator {
     }
 }
 
-impl Drop for DBIterator {
+impl<'a> Drop for DBIterator<'a> {
     fn drop(&mut self) {
         unsafe {
             ffi::rocksdb_iter_destroy(self.inner);

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -22,6 +22,7 @@ use std::path::{Path, PathBuf};
 use std::ptr;
 use std::slice;
 use std::str;
+use std::marker::PhantomData;
 
 use libc::{self, c_char, c_int, c_uchar, c_void, size_t};
 
@@ -83,13 +84,11 @@ pub struct Snapshot<'a> {
     inner: *const ffi::rocksdb_snapshot_t,
 }
 
-// We need to find a better way to add a lifetime in here.
-#[allow(dead_code)]
 pub struct DBIterator<'a> {
-    db: &'a DB,
     inner: *mut ffi::rocksdb_iterator_t,
     direction: Direction,
     just_seeked: bool,
+    phantom: PhantomData<&'a DB>,
 }
 
 pub enum Direction {
@@ -170,10 +169,10 @@ impl<'a> DBIterator<'a> {
             let iterator = ffi::rocksdb_create_iterator(db.inner, readopts.inner);
 
             let mut rv = DBIterator {
-                db: db,
                 inner: iterator,
                 direction: Direction::Forward, // blown away by set_mode()
                 just_seeked: false,
+                phantom: PhantomData,
             };
             rv.set_mode(mode);
             rv
@@ -215,10 +214,10 @@ impl<'a> DBIterator<'a> {
             let iterator = ffi::rocksdb_create_iterator_cf(db.inner, readopts.inner, cf_handle);
 
             let mut rv = DBIterator {
-                db: db,
                 inner: iterator,
                 direction: Direction::Forward, // blown away by set_mode()
                 just_seeked: false,
+                phantom: PhantomData,
             };
             rv.set_mode(mode);
             Ok(rv)

--- a/test/test_iterator.rs
+++ b/test/test_iterator.rs
@@ -13,119 +13,119 @@
 // limitations under the License.
 //
 
-use rocksdb::{DB, Direction, IteratorMode, Options, Writable};
+use rocksdb::{DB, Direction, IteratorMode, Options, Writable, Kv};
 
-fn cba(input: &Box<[u8]>) -> Box<[u8]> {
-    input.iter().cloned().collect::<Vec<_>>().into_boxed_slice()
+fn collect<'a, T: Iterator<Item=Kv<'a>>>(iter: T) -> Vec<(Vec<u8>, Vec<u8>)> {
+    iter.map(|(k, v)| (k.to_vec(), v.to_vec())).collect()
 }
 
 #[test]
 pub fn test_iterator() {
     let path = "_rust_rocksdb_iteratortest";
     {
-        let k1: Box<[u8]> = b"k1".to_vec().into_boxed_slice();
-        let k2: Box<[u8]> = b"k2".to_vec().into_boxed_slice();
-        let k3: Box<[u8]> = b"k3".to_vec().into_boxed_slice();
-        let k4: Box<[u8]> = b"k4".to_vec().into_boxed_slice();
-        let v1: Box<[u8]> = b"v1111".to_vec().into_boxed_slice();
-        let v2: Box<[u8]> = b"v2222".to_vec().into_boxed_slice();
-        let v3: Box<[u8]> = b"v3333".to_vec().into_boxed_slice();
-        let v4: Box<[u8]> = b"v4444".to_vec().into_boxed_slice();
+        let k1 = b"k1";
+        let k2 = b"k2";
+        let k3 = b"k3";
+        let k4 = b"k4";
+        let v1 = b"v1111";
+        let v2 = b"v2222";
+        let v3 = b"v3333";
+        let v4 = b"v4444";
         let db = DB::open_default(path).unwrap();
-        let p = db.put(&*k1, &*v1);
+        let p = db.put(k1, v1);
         assert!(p.is_ok());
-        let p = db.put(&*k2, &*v2);
+        let p = db.put(k2, v2);
         assert!(p.is_ok());
-        let p = db.put(&*k3, &*v3);
+        let p = db.put(k3, v3);
         assert!(p.is_ok());
-        let expected = vec![(cba(&k1), cba(&v1)),
-                            (cba(&k2), cba(&v2)),
-                            (cba(&k3), cba(&v3))];
+        let expected = vec![(k1.to_vec(), v1.to_vec()),
+                            (k2.to_vec(), v2.to_vec()),
+                            (k3.to_vec(), v3.to_vec())];
         {
             let iterator1 = db.iterator(IteratorMode::Start);
-            assert_eq!(iterator1.collect::<Vec<_>>(), expected);
+            assert_eq!(collect(iterator1), expected);
         }
         // Test that it's idempotent
         {
             let iterator1 = db.iterator(IteratorMode::Start);
-            assert_eq!(iterator1.collect::<Vec<_>>(), expected);
+            assert_eq!(collect(iterator1), expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::Start);
-            assert_eq!(iterator1.collect::<Vec<_>>(), expected);
+            assert_eq!(collect(iterator1), expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::Start);
-            assert_eq!(iterator1.collect::<Vec<_>>(), expected);
+            assert_eq!(collect(iterator1), expected);
         }
         // Test it in reverse a few times
         {
             let iterator1 = db.iterator(IteratorMode::End);
-            let mut tmp_vec = iterator1.collect::<Vec<_>>();
+            let mut tmp_vec = collect(iterator1);
             tmp_vec.reverse();
             assert_eq!(tmp_vec, expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::End);
-            let mut tmp_vec = iterator1.collect::<Vec<_>>();
+            let mut tmp_vec = collect(iterator1);
             tmp_vec.reverse();
             assert_eq!(tmp_vec, expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::End);
-            let mut tmp_vec = iterator1.collect::<Vec<_>>();
+            let mut tmp_vec = collect(iterator1);
             tmp_vec.reverse();
             assert_eq!(tmp_vec, expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::End);
-            let mut tmp_vec = iterator1.collect::<Vec<_>>();
+            let mut tmp_vec = collect(iterator1);
             tmp_vec.reverse();
             assert_eq!(tmp_vec, expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::End);
-            let mut tmp_vec = iterator1.collect::<Vec<_>>();
+            let mut tmp_vec = collect(iterator1);
             tmp_vec.reverse();
             assert_eq!(tmp_vec, expected);
         }
         // Try it forward again
         {
             let iterator1 = db.iterator(IteratorMode::Start);
-            assert_eq!(iterator1.collect::<Vec<_>>(), expected);
+            assert_eq!(collect(iterator1), expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::Start);
-            assert_eq!(iterator1.collect::<Vec<_>>(), expected);
+            assert_eq!(collect(iterator1), expected);
         }
 
         let old_iterator = db.iterator(IteratorMode::Start);
         let p = db.put(&*k4, &*v4);
         assert!(p.is_ok());
-        let expected2 = vec![(cba(&k1), cba(&v1)),
-                             (cba(&k2), cba(&v2)),
-                             (cba(&k3), cba(&v3)),
-                             (cba(&k4), cba(&v4))];
+        let expected2 = vec![(k1.to_vec(), v1.to_vec()),
+                             (k2.to_vec(), v2.to_vec()),
+                             (k3.to_vec(), v3.to_vec()),
+                             (k4.to_vec(), v4.to_vec())];
         {
-            assert_eq!(old_iterator.collect::<Vec<_>>(), expected);
+            assert_eq!(collect(old_iterator), expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::Start);
-            assert_eq!(iterator1.collect::<Vec<_>>(), expected2);
+            assert_eq!(collect(iterator1), expected2);
         }
         {
             let iterator1 =
                 db.iterator(IteratorMode::From(b"k2", Direction::Forward));
-            let expected = vec![(cba(&k2), cba(&v2)),
-                                (cba(&k3), cba(&v3)),
-                                (cba(&k4), cba(&v4))];
-            assert_eq!(iterator1.collect::<Vec<_>>(), expected);
+            let expected = vec![(k2.to_vec(), v2.to_vec()),
+                                (k3.to_vec(), v3.to_vec()),
+                                (k4.to_vec(), v4.to_vec())];
+            assert_eq!(collect(iterator1), expected);
         }
         {
             let iterator1 =
                 db.iterator(IteratorMode::From(b"k2", Direction::Reverse));
-            let expected = vec![(cba(&k2), cba(&v2)), (cba(&k1), cba(&v1))];
-            assert_eq!(iterator1.collect::<Vec<_>>(), expected);
+            let expected = vec![(k2.to_vec(), v2.to_vec()), (k1.to_vec(), v1.to_vec())];
+            assert_eq!(collect(iterator1), expected);
         }
         {
             let iterator1 =

--- a/test/test_iterator.rs
+++ b/test/test_iterator.rs
@@ -15,10 +15,6 @@
 
 use rocksdb::{DB, Direction, IteratorMode, Options, Writable, Kv};
 
-fn collect<'a, T: Iterator<Item=Kv<'a>>>(iter: T) -> Vec<(Vec<u8>, Vec<u8>)> {
-    iter.map(|(k, v)| (k.to_vec(), v.to_vec())).collect()
-}
-
 #[test]
 pub fn test_iterator() {
     let path = "_rust_rocksdb_iteratortest";
@@ -38,94 +34,87 @@ pub fn test_iterator() {
         assert!(p.is_ok());
         let p = db.put(k3, v3);
         assert!(p.is_ok());
-        let expected = vec![(k1.to_vec(), v1.to_vec()),
-                            (k2.to_vec(), v2.to_vec()),
-                            (k3.to_vec(), v3.to_vec())];
+        let expected: Vec<Kv> = vec![(k1, v1), (k2, v2), (k3, v3)];
         {
             let iterator1 = db.iterator(IteratorMode::Start);
-            assert_eq!(collect(iterator1), expected);
+            assert_eq!(iterator1.collect::<Vec<Kv>>(), expected);
         }
         // Test that it's idempotent
         {
             let iterator1 = db.iterator(IteratorMode::Start);
-            assert_eq!(collect(iterator1), expected);
+            assert_eq!(iterator1.collect::<Vec<Kv>>(), expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::Start);
-            assert_eq!(collect(iterator1), expected);
+            assert_eq!(iterator1.collect::<Vec<Kv>>(), expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::Start);
-            assert_eq!(collect(iterator1), expected);
+            assert_eq!(iterator1.collect::<Vec<Kv>>(), expected);
         }
         // Test it in reverse a few times
         {
             let iterator1 = db.iterator(IteratorMode::End);
-            let mut tmp_vec = collect(iterator1);
+            let mut tmp_vec = iterator1.collect::<Vec<Kv>>();
             tmp_vec.reverse();
             assert_eq!(tmp_vec, expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::End);
-            let mut tmp_vec = collect(iterator1);
+            let mut tmp_vec = iterator1.collect::<Vec<Kv>>();
             tmp_vec.reverse();
             assert_eq!(tmp_vec, expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::End);
-            let mut tmp_vec = collect(iterator1);
+            let mut tmp_vec = iterator1.collect::<Vec<Kv>>();
             tmp_vec.reverse();
             assert_eq!(tmp_vec, expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::End);
-            let mut tmp_vec = collect(iterator1);
+            let mut tmp_vec = iterator1.collect::<Vec<Kv>>();
             tmp_vec.reverse();
             assert_eq!(tmp_vec, expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::End);
-            let mut tmp_vec = collect(iterator1);
+            let mut tmp_vec = iterator1.collect::<Vec<Kv>>();
             tmp_vec.reverse();
             assert_eq!(tmp_vec, expected);
         }
         // Try it forward again
         {
             let iterator1 = db.iterator(IteratorMode::Start);
-            assert_eq!(collect(iterator1), expected);
+            assert_eq!(iterator1.collect::<Vec<Kv>>(), expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::Start);
-            assert_eq!(collect(iterator1), expected);
+            assert_eq!(iterator1.collect::<Vec<Kv>>(), expected);
         }
 
         let old_iterator = db.iterator(IteratorMode::Start);
         let p = db.put(&*k4, &*v4);
         assert!(p.is_ok());
-        let expected2 = vec![(k1.to_vec(), v1.to_vec()),
-                             (k2.to_vec(), v2.to_vec()),
-                             (k3.to_vec(), v3.to_vec()),
-                             (k4.to_vec(), v4.to_vec())];
+        let expected2: Vec<Kv> = vec![(k1, v1), (k2, v2), (k3, v3), (k4, v4)];
         {
-            assert_eq!(collect(old_iterator), expected);
+            assert_eq!(old_iterator.collect::<Vec<Kv>>(), expected);
         }
         {
             let iterator1 = db.iterator(IteratorMode::Start);
-            assert_eq!(collect(iterator1), expected2);
+            assert_eq!(iterator1.collect::<Vec<Kv>>(), expected2);
         }
         {
             let iterator1 =
                 db.iterator(IteratorMode::From(b"k2", Direction::Forward));
-            let expected = vec![(k2.to_vec(), v2.to_vec()),
-                                (k3.to_vec(), v3.to_vec()),
-                                (k4.to_vec(), v4.to_vec())];
-            assert_eq!(collect(iterator1), expected);
+            let expected: Vec<Kv> = vec![(k2, v2), (k3, v3), (k4, v4)];
+            assert_eq!(iterator1.collect::<Vec<Kv>>(), expected);
         }
         {
             let iterator1 =
                 db.iterator(IteratorMode::From(b"k2", Direction::Reverse));
-            let expected = vec![(k2.to_vec(), v2.to_vec()), (k1.to_vec(), v1.to_vec())];
-            assert_eq!(collect(iterator1), expected);
+            let expected: Vec<Kv> = vec![(k2, v2), (k1, v1)];
+            assert_eq!(iterator1.collect::<Vec<Kv>>(), expected);
         }
         {
             let iterator1 =


### PR DESCRIPTION
Part of #69 

This pulls in https://github.com/ngaut/rust-rocksdb/pull/9. I've made changes to how the lifetime is defined on `DBIterator` and tweaked the tests to make them work without copying.
