### PR TITLE
Pass in WriteBatch by reference and add `clear` method.

### DIFF
--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -400,7 +400,7 @@ impl DB {
         &self.path.as_path()
     }
 
-    pub fn write_opt(&self, batch: WriteBatch, writeopts: &WriteOptions) -> Result<(), Error> {
+    pub fn write_opt(&self, batch: &WriteBatch, writeopts: &WriteOptions) -> Result<(), Error> {
         let mut err: *mut c_char = ptr::null_mut();
         unsafe {
             ffi::rocksdb_write(self.inner, writeopts.inner, batch.inner, &mut err);
@@ -411,11 +411,11 @@ impl DB {
         Ok(())
     }
 
-    pub fn write(&self, batch: WriteBatch) -> Result<(), Error> {
+    pub fn write(&self, batch: &WriteBatch) -> Result<(), Error> {
         self.write_opt(batch, &WriteOptions::default())
     }
 
-    pub fn write_without_wal(&self, batch: WriteBatch) -> Result<(), Error> {
+    pub fn write_without_wal(&self, batch: &WriteBatch) -> Result<(), Error> {
         let mut wo = WriteOptions::new();
         wo.disable_wal(true);
         self.write_opt(batch, &wo)
@@ -623,6 +623,10 @@ impl WriteBatch {
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    pub fn clear(&self) {
+        unsafe { ffi::rocksdb_writebatch_clear(self.inner) }
     }
 }
 


### PR DESCRIPTION
If you use WriteBatch'es within your project as kind of a buffer you
occasionally flush into RocksDB, it might be part of a struct. It's
difficult to move a single field out of a struct. Hence it is easier
if the methods on WriteBatch would take a WriteBatch by reference
and you call `clear()` on it manually once done.

I can see the point of the original API, though in my use case it's
hard (almost impossible) to use it that way. Though perhaps I'm
missing something and there is a nice way to move a single field
out of a borrowed struct.