### PR TITLE
Add some documentation and wrap column_family_t

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -510,14 +510,14 @@ impl DB {
                     .to_owned()))
             }
         };
-        let cf_handler = unsafe {
+        let cf = unsafe {
             let cf_handler =
                 ffi_try!(ffi::rocksdb_create_column_family(self.inner, opts.inner, cname.as_ptr()));
-            let cf_handler = ColumnFamily { inner: cf_handler };
-            self.cfs.insert(name.to_string(), cf_handler);
-            cf_handler
+            let cf = ColumnFamily { inner: cf_handler };
+            self.cfs.insert(name.to_string(), cf);
+            cf
         };
-        Ok(cf_handler)
+        Ok(cf)
     }
 
     pub fn drop_cf(&mut self, name: &str) -> Result<(), Error> {
@@ -533,7 +533,7 @@ impl DB {
 
     /// Return the underlying column family handle.
     pub fn cf_handle(&self, name: &str) -> Option<ColumnFamily> {
-        self.cfs.get(name).map(|cf| *cf)
+        self.cfs.get(name).cloned()
     }
 
     pub fn iterator(&self, mode: IteratorMode) -> DBIterator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,12 +55,16 @@ use std::fmt;
 use std::path::PathBuf;
 
 /// A RocksDB database.
+///
+/// See crate level documentation for a simple usage example.
 pub struct DB {
     inner: *mut ffi::rocksdb_t,
-    cfs: BTreeMap<String, *mut ffi::rocksdb_column_family_handle_t>,
+    cfs: BTreeMap<String, ColumnFamily>,
     path: PathBuf,
 }
 
+/// A simple wrapper round a string, used for errors reported from
+/// ffi calls.
 #[derive(Debug, PartialEq)]
 pub struct Error {
     message: String,
@@ -161,4 +165,11 @@ pub struct Options {
 /// ```
 pub struct WriteOptions {
     inner: *mut ffi::rocksdb_writeoptions_t,
+}
+
+/// An opaque type used to represent a column family. Returned from some functions, and used
+/// in others
+#[derive(Copy, Clone)]
+pub struct ColumnFamily {
+    inner: *mut ffi::rocksdb_column_family_handle_t,
 }

--- a/test/test_column_family.rs
+++ b/test/test_column_family.rs
@@ -94,7 +94,7 @@ fn test_merge_operator() {
             }
             Err(e) => panic!("failed to open db with column family: {}", e),
         };
-        let cf1 = *db.cf_handle("cf1").unwrap();
+        let cf1 = db.cf_handle("cf1").unwrap();
         assert!(db.put_cf(cf1, b"k1", b"v1").is_ok());
         assert!(db.get_cf(cf1, b"k1").unwrap().unwrap().to_utf8().unwrap() == "v1");
         let p = db.put_cf(cf1, b"k1", b"a");


### PR DESCRIPTION
The main change is to hide column_family_t behind a containing struct, so there are no raw pointers in the api. Strictly speaking this isn't necesary as the objects are used in an opaque way, but I think it makes the docs nicer.

I've also documented a few things, and marked the DBVector from_c function as unsafe, as the wrong length can cause undefined behaviour