### PR TITLE
Replace cast `as *const i8` with `as *const c_char` to prevent compile errors in 32-bit ARM systems

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -609,9 +609,9 @@ impl DB {
             ffi_try!(ffi::rocksdb_merge_cf(self.inner,
                                            writeopts.inner,
                                            cf.inner,
-                                           key.as_ptr() as *const i8,
+                                           key.as_ptr() as *const c_char,
                                            key.len() as size_t,
-                                           value.as_ptr() as *const i8,
+                                           value.as_ptr() as *const c_char,
                                            value.len() as size_t));
             Ok(())
         }
@@ -715,9 +715,9 @@ impl WriteBatch {
     pub fn put(&mut self, key: &[u8], value: &[u8]) -> Result<(), Error> {
         unsafe {
             ffi::rocksdb_writebatch_put(self.inner,
-                                        key.as_ptr() as *const i8,
+                                        key.as_ptr() as *const c_char,
                                         key.len() as size_t,
-                                        value.as_ptr() as *const i8,
+                                        value.as_ptr() as *const c_char,
                                         value.len() as size_t);
             Ok(())
         }
@@ -731,9 +731,9 @@ impl WriteBatch {
         unsafe {
             ffi::rocksdb_writebatch_put_cf(self.inner,
                                            cf.inner,
-                                           key.as_ptr() as *const i8,
+                                           key.as_ptr() as *const c_char,
                                            key.len() as size_t,
-                                           value.as_ptr() as *const i8,
+                                           value.as_ptr() as *const c_char,
                                            value.len() as size_t);
             Ok(())
         }
@@ -742,9 +742,9 @@ impl WriteBatch {
     pub fn merge(&mut self, key: &[u8], value: &[u8]) -> Result<(), Error> {
         unsafe {
             ffi::rocksdb_writebatch_merge(self.inner,
-                                          key.as_ptr() as *const i8,
+                                          key.as_ptr() as *const c_char,
                                           key.len() as size_t,
-                                          value.as_ptr() as *const i8,
+                                          value.as_ptr() as *const c_char,
                                           value.len() as size_t);
             Ok(())
         }
@@ -758,9 +758,9 @@ impl WriteBatch {
         unsafe {
             ffi::rocksdb_writebatch_merge_cf(self.inner,
                                              cf.inner,
-                                             key.as_ptr() as *const i8,
+                                             key.as_ptr() as *const c_char,
                                              key.len() as size_t,
-                                             value.as_ptr() as *const i8,
+                                             value.as_ptr() as *const c_char,
                                              value.len() as size_t);
             Ok(())
         }
@@ -772,7 +772,7 @@ impl WriteBatch {
     pub fn delete(&mut self, key: &[u8]) -> Result<(), Error> {
         unsafe {
             ffi::rocksdb_writebatch_delete(self.inner,
-                                           key.as_ptr() as *const i8,
+                                           key.as_ptr() as *const c_char,
                                            key.len() as size_t);
             Ok(())
         }
@@ -785,7 +785,7 @@ impl WriteBatch {
         unsafe {
             ffi::rocksdb_writebatch_delete_cf(self.inner,
                                               cf.inner,
-                                              key.as_ptr() as *const i8,
+                                              key.as_ptr() as *const c_char,
                                               key.len() as size_t);
             Ok(())
         }
@@ -847,7 +847,7 @@ impl ReadOptions {
     pub fn set_iterate_upper_bound(&mut self, key: &[u8]) {
         unsafe {
             ffi::rocksdb_readoptions_set_iterate_upper_bound(self.inner,
-                                                             key.as_ptr() as *const i8,
+                                                             key.as_ptr() as *const c_char,
                                                              key.len() as size_t);
         }
     }


### PR DESCRIPTION
This change solves the following type mismatch error in 32-bit ARM Linux systems (for example, `armv7-unknown-linux-gnueabihf` target). This is done by replacing type cast `as *const i8` with `as *const c_char` in db.rs.

```
error[E0308]: mismatched types
   --> src/db.rs:612:44
    |
609 |             ffi_try!(ffi::rocksdb_merge_cf(self.inner,
    |             - in this macro invocation
...
612 |                                            key.as_ptr() as *const i8,
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^ expected u8, found i8

error[E0308]: mismatched types
   --> src/db.rs:614:44
    |
609 |             ffi_try!(ffi::rocksdb_merge_cf(self.inner,
    |             - in this macro invocation
...
614 |                                            value.as_ptr() as *const i8,
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected u8, found i8

...(the same error repeating on other lines)...

error: aborting due to 13 previous errors
```

### Details

The lines that got the error above is casting `key` and `value` pointers as platform independent `*const i8`. 

e.g. src/db.rs
```rust
            ffi_try!(ffi::rocksdb_merge_cf(self.inner,
                                           writeopts.inner,
                                           cf.inner,
                                           key.as_ptr() as *const i8,
                                           key.len() as size_t,
                                           value.as_ptr() as *const i8,
                                           value.len() as size_t));
```

However, in librocksdb-sys, those functions take platform dependent `*const c_char` for key and value.

e.g.
```rust
    pub fn rocksdb_merge_cf(db: *mut rocksdb_t,
                            options: *const rocksdb_writeoptions_t,
                            column_family: *mut rocksdb_column_family_handle_t,
                            key: *const c_char,
                            keylen: size_t,
                            val: *const c_char,
                            vallen: size_t,
                            errptr: *mut *mut c_char);
```

These discrepancies will be OK on 64-bit Linux and some other systems because `c_char` on those systems is a type alias of `i8`.

[rust-lang/libc/src/unix/notbsd/linux/other/b64/x86_64.rs](https://github.com/rust-lang/libc/blob/67615b49d5ea47c69207987dbb6cff8297821a8b/src/unix/notbsd/linux/other/b64/x86_64.rs#L3)
```rust
pub type c_char = i8;
```

However, this is not true on 32-bit ARM Linux.

[rust-lang/libc/src/unix/notbsd/linux/other/b32/arm.rs](https://github.com/rust-lang/libc/blob/7590565993b0298aa754bfdf4267fea9c71f08f2/src/unix/notbsd/linux/other/b32/arm.rs)
```rust
pub type c_char = u8;
```

This pull request replaces those type casts `as *const i8` with `as *const c_char`, so that they can compile on both 64-bit and 32-bit systems.