### PR TITLE
Fail if RocksDB or Snappy source is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ Feedback and pull requests welcome!  If a particular feature of RocksDB is impor
 [dependencies]
 rocksdb = "0.6.0"
 ```
+
+This binding is statically linked with a specific version of RocksDB. If you want to build it yourself, make sure you've also cloned the RocksDB and Snappy submodules:
+
+    git submodule update --init --recursive

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -1,5 +1,7 @@
 extern crate gcc;
 
+use std::fs;
+
 fn link(name: &str, bundled: bool) {
     use std::env::var;
     let target = var("TARGET").unwrap();
@@ -10,6 +12,14 @@ fn link(name: &str, bundled: bool) {
             let dir = var("CARGO_MANIFEST_DIR").unwrap();
             println!("cargo:rustc-link-search=native={}/{}", dir, target[0]);
         }
+    }
+}
+
+fn fail_on_empty_directory(name: &str) {
+    if fs::read_dir(name).unwrap().count() == 0 {
+        println!("The `{}` directory is empty, did you forget to pull the submodules?", name);
+        println!("Try `git submodule update --init --recursive`");
+        panic!();
     }
 }
 
@@ -118,6 +128,8 @@ fn build_snappy() {
 }
 
 fn main() {
+    fail_on_empty_directory("rocksdb");
+    fail_on_empty_directory("snappy");
     build_rocksdb();
     build_snappy();
 }


### PR DESCRIPTION
When I tried to build via `cargo build` I saw a lot of error messages and had no clue what was wrong. I hope with this patch things get a little bit clearer if people run into similar issues.