### PR TITLE
Raw iterators

### DIFF
--- a/librocksdb-sys/src/lib.rs
+++ b/librocksdb-sys/src/lib.rs
@@ -294,8 +294,6 @@ extern "C" {
 
     pub fn rocksdb_iter_seek(iterator: *mut rocksdb_iterator_t, k: *const c_char, klen: size_t);
 
-    pub fn rocksdb_iter_seek_for_prev(iterator: *mut rocksdb_iterator_t, k: *const c_char, klen: size_t);
-
     pub fn rocksdb_iter_next(iterator: *mut rocksdb_iterator_t);
 
     pub fn rocksdb_iter_prev(iterator: *mut rocksdb_iterator_t);

--- a/librocksdb-sys/src/lib.rs
+++ b/librocksdb-sys/src/lib.rs
@@ -294,6 +294,8 @@ extern "C" {
 
     pub fn rocksdb_iter_seek(iterator: *mut rocksdb_iterator_t, k: *const c_char, klen: size_t);
 
+    pub fn rocksdb_iter_seek_for_prev(iterator: *mut rocksdb_iterator_t, k: *const c_char, klen: size_t);
+
     pub fn rocksdb_iter_next(iterator: *mut rocksdb_iterator_t);
 
     pub fn rocksdb_iter_prev(iterator: *mut rocksdb_iterator_t);

--- a/src/db.rs
+++ b/src/db.rs
@@ -132,10 +132,6 @@ pub struct Snapshot<'a> {
 ///     println!("Saw {:?} {:?}", iter.key(), iter.value());
 /// }
 ///
-/// iter.seek_for_prev(b"my key");
-/// while iter.prev() {
-///     println!("Saw {:?} {:?}", iter.key(), iter.value());
-/// }
 /// ```
 pub struct DBRawIterator {
     inner: *mut ffi::rocksdb_iterator_t,
@@ -359,6 +355,9 @@ impl DBRawIterator {
         self.just_seeked = true;
     }
 
+/*
+    SeekForPrev was added in RocksDB 4.13 but not implemented in the C API until RocksDB 5.0
+
     /// Seeks to the specified key, or the first key that lexicographically precedes it.
     ///
     /// Like ``.seek()`` this method will attempt to seek to the specified key.
@@ -388,6 +387,7 @@ impl DBRawIterator {
         unsafe { ffi::rocksdb_iter_seek_for_prev(self.inner, key.as_ptr() as *const c_char, key.len() as size_t); }
         self.just_seeked = true;
     }
+*/
 
     /// Seeks to the next key.
     ///

--- a/src/db.rs
+++ b/src/db.rs
@@ -111,7 +111,7 @@ pub struct Snapshot<'a> {
 /// ```
 /// use rocksdb::DB;
 ///
-/// let mut db = DB::open_default("path/for/rocksdb/storage2").unwrap();
+/// let mut db = DB::open_default("path/for/rocksdb/storage4").unwrap();
 /// let mut iter = db.raw_iterator();
 ///
 /// // Forwards iteration
@@ -127,12 +127,12 @@ pub struct Snapshot<'a> {
 /// }
 ///
 /// // Seeking
-/// iter = iter.seek(b"my key");
+/// iter.seek(b"my key");
 /// while iter.next() {
 ///     println!("Saw {:?} {:?}", iter.key(), iter.value());
 /// }
 ///
-/// iter = iter.seek_for_prev(b"my key");
+/// iter.seek_for_prev(b"my key");
 /// while iter.prev() {
 ///     println!("Saw {:?} {:?}", iter.key(), iter.value());
 /// }
@@ -262,24 +262,27 @@ impl DBRawIterator {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```rust
+    /// use rocksdb::DB;
+    ///
+    /// let mut db = DB::open_default("path/for/rocksdb/storage5").unwrap();
+    /// let mut iter = db.raw_iterator();
+    ///
     /// // Iterate all keys from the start in lexicographic order
     ///
-    /// iterator.seek_to_first();
+    /// iter.seek_to_first();
     ///
-    /// while iterator.next() {
-    ///    println!("{:?} {:?}", iterator.key(), iterator.value());
+    /// while iter.next() {
+    ///    println!("{:?} {:?}", iter.key(), iter.value());
     /// }
-    /// ```
     ///
-    /// ```rust,no_run
     /// // Read just the first key
     ///
-    /// iterator.seek_to_first();
+    /// iter.seek_to_first();
     ///
-    /// let is_valid = iterator.next();
+    /// let is_valid = iter.next();
     /// if is_valid {
-    ///    println!("{:?} {:?}", iterator.key(), iterator.value());
+    ///    println!("{:?} {:?}", iter.key(), iter.value());
     /// } else {
     ///    // There are no keys in the database
     /// }
@@ -295,24 +298,27 @@ impl DBRawIterator {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```rust
+    /// use rocksdb::DB;
+    ///
+    /// let mut db = DB::open_default("path/for/rocksdb/storage6").unwrap();
+    /// let mut iter = db.raw_iterator();
+    ///
     /// // Iterate all keys from the end in reverse lexicographic order
     ///
-    /// iterator.seek_to_last();
+    /// iter.seek_to_last();
     ///
-    /// while iterator.prev() {
-    ///    println!("{:?} {:?}", iterator.key(), iterator.value());;
+    /// while iter.prev() {
+    ///    println!("{:?} {:?}", iter.key(), iter.value());;
     /// }
-    /// ```
     ///
-    /// ```rust,no_run
     /// // Read just the last key
     ///
-    /// iterator.seek_to_last();
+    /// iter.seek_to_last();
     ///
-    /// let is_valid = iterator.prev();
+    /// let is_valid = iter.prev();
     /// if is_valid {
-    ///    println!("{:?} {:?}", iterator.key(), iterator.value());
+    ///    println!("{:?} {:?}", iter.key(), iter.value());
     /// } else {
     ///    // There are no keys in the database
     /// }
@@ -331,14 +337,19 @@ impl DBRawIterator {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```rust
+    /// use rocksdb::DB;
+    ///
+    /// let mut db = DB::open_default("path/for/rocksdb/storage7").unwrap();
+    /// let mut iter = db.raw_iterator();
+    ///
     /// // Read the first key that starts with 'a'
     ///
-    /// iterator.seek(b"a");
+    /// iter.seek(b"a");
     ///
-    /// let is_valid = iterator.next();
+    /// let is_valid = iter.next();
     /// if is_valid {
-    ///    println!("{:?} {:?}", iterator.key(), iterator.value());
+    ///    println!("{:?} {:?}", iter.key(), iter.value());
     /// } else {
     ///    // There are no keys in the database
     /// }
@@ -357,14 +368,19 @@ impl DBRawIterator {
     /// Like the other seek methods, you must call ``.next()`` or ``.prev()`` before reading a key.
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```rust
+    /// use rocksdb::DB;
+    ///
+    /// let mut db = DB::open_default("path/for/rocksdb/storage8").unwrap();
+    /// let mut iter = db.raw_iterator();
+    ///
     /// // Read the last key that starts with 'a'
     ///
-    /// iterator.seek_for_prev(b"b");
+    /// iter.seek_for_prev(b"b");
     ///
-    /// let is_valid = iterator.prev();
+    /// let is_valid = iter.prev();
     /// if is_valid {
-    ///    println!("{:?} {:?}", iterator.key(), iterator.value());
+    ///    println!("{:?} {:?}", iter.key(), iter.value());
     /// } else {
     ///    // There are no keys in the database
     /// }

--- a/src/db.rs
+++ b/src/db.rs
@@ -514,6 +514,12 @@ impl Iterator for DBIterator {
     }
 }
 
+impl Into<DBRawIterator> for DBIterator {
+    fn into(self) -> DBRawIterator {
+        self.raw
+    }
+}
+
 impl<'a> Snapshot<'a> {
     pub fn new(db: &DB) -> Snapshot {
         let snapshot = unsafe { ffi::rocksdb_create_snapshot(db.inner) };

--- a/src/db.rs
+++ b/src/db.rs
@@ -260,12 +260,10 @@ impl DBRawIterator {
         self.just_seeked = true;
     }
 
-/*
-    pub fn seek_for_prev(&mut self, key: [u8]) {
+    pub fn seek_for_prev(&mut self, key: &[u8]) {
         unsafe { ffi::rocksdb_iter_seek_for_prev(self.inner, key.as_ptr() as *const c_char, key.len() as size_t); }
         self.just_seeked = true;
     }
-*/
 
     pub fn next(&mut self) -> bool {
         // Initial call to next() after seeking should not move the iterator

--- a/src/db.rs
+++ b/src/db.rs
@@ -294,7 +294,7 @@ impl DBRawIterator {
         self.valid()
     }
 
-    pub unsafe fn key<'a>(&'a self) -> Option<&'a [u8]> {
+    pub unsafe fn key_inner<'a>(&'a self) -> Option<&'a [u8]> {
         if self.valid() {
             let mut key_len: size_t = 0;
             let key_len_ptr: *mut size_t = &mut key_len;
@@ -306,7 +306,13 @@ impl DBRawIterator {
         }
     }
 
-    pub unsafe fn value<'a>(&'a self) -> Option<&'a [u8]> {
+    pub fn key(&self) -> Option<Vec<u8>> {
+        unsafe {
+            self.key_inner().map(|key| key.to_vec())
+        }
+    }
+
+    pub unsafe fn value_inner<'a>(&'a self) -> Option<&'a [u8]> {
         if self.valid() {
             let mut val_len: size_t = 0;
             let val_len_ptr: *mut size_t = &mut val_len;
@@ -315,6 +321,12 @@ impl DBRawIterator {
             Some(slice::from_raw_parts(val_ptr, val_len as usize))
         } else {
             None
+        }
+    }
+
+    pub fn value(&self) -> Option<Vec<u8>> {
+        unsafe {
+            self.value_inner().map(|value| value.to_vec())
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub mod compaction_filter;
 mod db;
 mod db_options;
 
-pub use db::{DBCompactionStyle, DBCompressionType, DBIterator, DBRecoveryMode, DBVector,
+pub use db::{DBCompactionStyle, DBCompressionType, DBIterator, DBRawIterator, DBRecoveryMode, DBVector,
              Direction, IteratorMode, Snapshot, WriteBatch, new_bloom_filter};
 
 pub use merge_operator::MergeOperands;

--- a/test/test.rs
+++ b/test/test.rs
@@ -16,6 +16,7 @@
 extern crate rocksdb;
 
 mod test_iterator;
+mod test_raw_iterator;
 mod test_multithreaded;
 mod test_column_family;
 mod test_rocksdb_options;

--- a/test/test_raw_iterator.rs
+++ b/test/test_raw_iterator.rs
@@ -41,32 +41,20 @@ pub fn test_forwards_iteration() {
     let mut iter = db.raw_iterator();
     iter.seek_to_first();
 
-    // Shouldn't be valid yet
-    assert_eq!(iter.valid(), false);
-    assert_eq!(iter.key(), None);
-    assert_eq!(iter.value(), None);
-
-    let valid = iter.next();
-
-    assert_eq!(valid, true);
     assert_eq!(iter.valid(), true);
     assert_eq!(iter.key(), Some(b"k1".to_vec()));
     assert_eq!(iter.value(), Some(b"v1".to_vec()));
 
-    let valid = iter.next();
+    iter.next();
 
-    assert_eq!(valid, true);
     assert_eq!(iter.valid(), true);
     assert_eq!(iter.key(), Some(b"k2".to_vec()));
     assert_eq!(iter.value(), Some(b"v2".to_vec()));
 
     iter.next();  // k3
     iter.next();  // k4
+    iter.next();  // invalid!
 
-    let valid = iter.next();
-
-    // Should be invalid again
-    assert_eq!(valid, false);
     assert_eq!(iter.valid(), false);
     assert_eq!(iter.key(), None);
     assert_eq!(iter.value(), None);
@@ -84,32 +72,20 @@ pub fn test_seek_last() {
     let mut iter = db.raw_iterator();
     iter.seek_to_last();
 
-    // Shouldn't be valid yet
-    assert_eq!(iter.valid(), false);
-    assert_eq!(iter.key(), None);
-    assert_eq!(iter.value(), None);
-
-    let valid = iter.prev();
-
-    assert_eq!(valid, true);
     assert_eq!(iter.valid(), true);
     assert_eq!(iter.key(), Some(b"k4".to_vec()));
     assert_eq!(iter.value(), Some(b"v4".to_vec()));
 
-    let valid = iter.prev();
+    iter.prev();
 
-    assert_eq!(valid, true);
     assert_eq!(iter.valid(), true);
     assert_eq!(iter.key(), Some(b"k3".to_vec()));
     assert_eq!(iter.value(), Some(b"v3".to_vec()));
 
     iter.prev();  // k2
     iter.prev();  // k1
+    iter.prev();  // invalid!
 
-    let valid = iter.prev();
-
-    // Should be invalid again
-    assert_eq!(valid, false);
     assert_eq!(iter.valid(), false);
     assert_eq!(iter.key(), None);
     assert_eq!(iter.value(), None);
@@ -127,41 +103,6 @@ pub fn test_seek() {
     let mut iter = db.raw_iterator();
     iter.seek(b"k2");
 
-    // Shouldn't be valid yet
-    assert_eq!(iter.valid(), false);
-    assert_eq!(iter.key(), None);
-    assert_eq!(iter.value(), None);
-
-    let valid = iter.next();
-
-    // Should now be valid
-    assert_eq!(valid, true);
-    assert_eq!(iter.valid(), true);
-    assert_eq!(iter.key(), Some(b"k2".to_vec()));
-    assert_eq!(iter.value(), Some(b"v2".to_vec()));
-}
-
-
-#[test]
-pub fn test_seek_then_prev() {
-    let db = setup_test_db("seek_then_prev");
-    db.put(b"k1", b"v1").unwrap();
-    db.put(b"k2", b"v2").unwrap();
-    db.put(b"k3", b"v3").unwrap();
-    db.put(b"k4", b"v4").unwrap();
-
-    let mut iter = db.raw_iterator();
-    iter.seek(b"k2");
-
-    // Shouldn't be valid yet
-    assert_eq!(iter.valid(), false);
-    assert_eq!(iter.key(), None);
-    assert_eq!(iter.value(), None);
-
-    let valid = iter.prev();
-
-    // Should now be valid
-    assert_eq!(valid, true);
     assert_eq!(iter.valid(), true);
     assert_eq!(iter.key(), Some(b"k2".to_vec()));
     assert_eq!(iter.value(), Some(b"v2".to_vec()));
@@ -178,14 +119,6 @@ pub fn test_seek_to_nonexistant() {
     let mut iter = db.raw_iterator();
     iter.seek(b"k2");
 
-    // Shouldn't be valid yet
-    assert_eq!(iter.valid(), false);
-    assert_eq!(iter.key(), None);
-    assert_eq!(iter.value(), None);
-
-    let valid = iter.next();
-
-    assert_eq!(valid, true);
     assert_eq!(iter.valid(), true);
     assert_eq!(iter.key(), Some(b"k3".to_vec()));
     assert_eq!(iter.value(), Some(b"v3".to_vec()));

--- a/test/test_raw_iterator.rs
+++ b/test/test_raw_iterator.rs
@@ -1,0 +1,192 @@
+// Copyright 2014 Tyler Neely
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use rocksdb::DB;
+
+
+fn setup_test_db(name: &str) -> DB {
+    use std::fs::remove_dir_all;
+
+    let path = "_rust_rocksdb_rawiteratortest_".to_string() + name;
+
+    match remove_dir_all(&path) {
+        Ok(_) => {}
+        Err(_) => {}  // Don't care if tis fails
+    }
+
+    DB::open_default(path).unwrap()
+}
+
+
+#[test]
+pub fn test_forwards_iteration() {
+    let db = setup_test_db("forwards_iteration");
+    db.put(b"k1", b"v1").unwrap();
+    db.put(b"k2", b"v2").unwrap();
+    db.put(b"k3", b"v3").unwrap();
+    db.put(b"k4", b"v4").unwrap();
+
+    let mut iter = db.raw_iterator();
+    iter.seek_to_first();
+
+    // Shouldn't be valid yet
+    assert_eq!(iter.valid(), false);
+    assert_eq!(iter.key(), None);
+    assert_eq!(iter.value(), None);
+
+    let valid = iter.next();
+
+    assert_eq!(valid, true);
+    assert_eq!(iter.valid(), true);
+    assert_eq!(iter.key(), Some(b"k1".to_vec()));
+    assert_eq!(iter.value(), Some(b"v1".to_vec()));
+
+    let valid = iter.next();
+
+    assert_eq!(valid, true);
+    assert_eq!(iter.valid(), true);
+    assert_eq!(iter.key(), Some(b"k2".to_vec()));
+    assert_eq!(iter.value(), Some(b"v2".to_vec()));
+
+    iter.next();  // k3
+    iter.next();  // k4
+
+    let valid = iter.next();
+
+    // Should be invalid again
+    assert_eq!(valid, false);
+    assert_eq!(iter.valid(), false);
+    assert_eq!(iter.key(), None);
+    assert_eq!(iter.value(), None);
+}
+
+
+#[test]
+pub fn test_seek_last() {
+    let db = setup_test_db("backwards_iteration");
+    db.put(b"k1", b"v1").unwrap();
+    db.put(b"k2", b"v2").unwrap();
+    db.put(b"k3", b"v3").unwrap();
+    db.put(b"k4", b"v4").unwrap();
+
+    let mut iter = db.raw_iterator();
+    iter.seek_to_last();
+
+    // Shouldn't be valid yet
+    assert_eq!(iter.valid(), false);
+    assert_eq!(iter.key(), None);
+    assert_eq!(iter.value(), None);
+
+    let valid = iter.prev();
+
+    assert_eq!(valid, true);
+    assert_eq!(iter.valid(), true);
+    assert_eq!(iter.key(), Some(b"k4".to_vec()));
+    assert_eq!(iter.value(), Some(b"v4".to_vec()));
+
+    let valid = iter.prev();
+
+    assert_eq!(valid, true);
+    assert_eq!(iter.valid(), true);
+    assert_eq!(iter.key(), Some(b"k3".to_vec()));
+    assert_eq!(iter.value(), Some(b"v3".to_vec()));
+
+    iter.prev();  // k2
+    iter.prev();  // k1
+
+    let valid = iter.prev();
+
+    // Should be invalid again
+    assert_eq!(valid, false);
+    assert_eq!(iter.valid(), false);
+    assert_eq!(iter.key(), None);
+    assert_eq!(iter.value(), None);
+}
+
+
+#[test]
+pub fn test_seek() {
+    let db = setup_test_db("seek");
+    db.put(b"k1", b"v1").unwrap();
+    db.put(b"k2", b"v2").unwrap();
+    db.put(b"k3", b"v3").unwrap();
+    db.put(b"k4", b"v4").unwrap();
+
+    let mut iter = db.raw_iterator();
+    iter.seek(b"k2");
+
+    // Shouldn't be valid yet
+    assert_eq!(iter.valid(), false);
+    assert_eq!(iter.key(), None);
+    assert_eq!(iter.value(), None);
+
+    let valid = iter.next();
+
+    // Should now be valid
+    assert_eq!(valid, true);
+    assert_eq!(iter.valid(), true);
+    assert_eq!(iter.key(), Some(b"k2".to_vec()));
+    assert_eq!(iter.value(), Some(b"v2".to_vec()));
+}
+
+
+#[test]
+pub fn test_seek_then_prev() {
+    let db = setup_test_db("seek_then_prev");
+    db.put(b"k1", b"v1").unwrap();
+    db.put(b"k2", b"v2").unwrap();
+    db.put(b"k3", b"v3").unwrap();
+    db.put(b"k4", b"v4").unwrap();
+
+    let mut iter = db.raw_iterator();
+    iter.seek(b"k2");
+
+    // Shouldn't be valid yet
+    assert_eq!(iter.valid(), false);
+    assert_eq!(iter.key(), None);
+    assert_eq!(iter.value(), None);
+
+    let valid = iter.prev();
+
+    // Should now be valid
+    assert_eq!(valid, true);
+    assert_eq!(iter.valid(), true);
+    assert_eq!(iter.key(), Some(b"k2".to_vec()));
+    assert_eq!(iter.value(), Some(b"v2".to_vec()));
+}
+
+
+#[test]
+pub fn test_seek_to_nonexistant() {
+    let db = setup_test_db("seek_to_nonexistant");
+    db.put(b"k1", b"v1").unwrap();
+    db.put(b"k3", b"v3").unwrap();
+    db.put(b"k4", b"v4").unwrap();
+
+    let mut iter = db.raw_iterator();
+    iter.seek(b"k2");
+
+    // Shouldn't be valid yet
+    assert_eq!(iter.valid(), false);
+    assert_eq!(iter.key(), None);
+    assert_eq!(iter.value(), None);
+
+    let valid = iter.next();
+
+    assert_eq!(valid, true);
+    assert_eq!(iter.valid(), true);
+    assert_eq!(iter.key(), Some(b"k3".to_vec()));
+    assert_eq!(iter.value(), Some(b"v3".to_vec()));
+}


### PR DESCRIPTION
This pull request implements an alternative iterator API that closely matches the underlying the iterators API in RocksDB. It gives access to all the flexibility and performance of RocksDB but the API it implements is quite different to what Rust developers are used to.

This can replace both of by earlier iterator pull requests #70 and #84

Example usage:

```rust
let mut iter = db.raw_iterator();
iter.seek_to_first();
while iter.valid() {
    let key = iter.key().unwrap();
    let value = iter.value().unwrap();

    // ...

    iter.next();
 }

// Reverse iteration
let mut reverse_iter = db.raw_iterator();
reverse_iter.seek_to_last();
while reverse_iter.valid() {
    let key = reverse_iter.key().unwrap();
    let value = reverse_iter.value().unwrap();

    // ...

    reverse_iter.prev();
 }

// Fowards iteration from a specified key
let mut seek_iter = db.raw_iterator();
seek_iter.seek(b"foo");
while seek_iter.valid() {
    let key = seek_iter.key().unwrap();
    let value = seek_iter.value().unwrap();

    // ...

    seek_iter.next();
 }
```

Here's an example of how this API can be misused:

```rust
let mut iter = db.raw_iterator();

let key1 = unsafe { iter.key_inner().unwrap() };

iter.next();
let key2 = unsafe { iter.key_inner().unwrap() };

println!("{} {}", key1, key2);  // Prints the value of key2 twice
```
(note: this only happens with the ``*_inner()`` methods as ``.key()`` and ``.value()`` always copy)

Also, forgetting to call ``.next()`` or ``.prev()`` will cause the application to hang.

TODO:

 - [x] Safe versions of ``.key()`` and ``.value()`` that copy (I'll probably make the safe versions the default and rename the unsafe ones to something like ``.key_inner()`` and ``.value_inner()``)
 - [x] Implement DBIterator on top of DBRawIterator
 - [x] Tests
 - [x] Documentation