### PR TITLE
Make BackupEngine methods public

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -58,14 +58,14 @@ impl BackupEngine {
         Ok(BackupEngine { inner: be })
     }
 
-    fn create_new_backup(&mut self, db: &DB) -> Result<(), Error> {
+    pub fn create_new_backup(&mut self, db: &DB) -> Result<(), Error> {
         unsafe {
             ffi_try!(ffi::rocksdb_backup_engine_create_new_backup(self.inner, db.inner));
             Ok(())
         }
     }
 
-    fn purge_old_backups(&mut self, num_backups_to_keep: usize) -> Result<(), Error> {
+    pub fn purge_old_backups(&mut self, num_backups_to_keep: usize) -> Result<(), Error> {
         unsafe {
             ffi_try!(ffi::rocksdb_backup_engine_purge_old_backups(self.inner,
                                                                   num_backups_to_keep as uint32_t));


### PR DESCRIPTION
In the `BackupEngine` the `create_new_backup` and `purge_old_backups`
methods were private, leading to those warnings.

warning: method is never used: `create_new_backup`, #[warn(dead_code)] on by default
  --> src/backup.rs:61:5
   |
61 |       fn create_new_backup(&mut self, db: &DB) -> Result<(), Error> {
   |  _____^ starting here...
62 | |         unsafe {
63 | |             ffi_try!(ffi::rocksdb_backup_engine_create_new_backup(self.inner, db.inner));
64 | |             Ok(())
65 | |         }
66 | |     }
   | |_____^ ...ending here

warning: method is never used: `purge_old_backups`, #[warn(dead_code)] on by default
  --> src/backup.rs:68:5
   |
68 |       fn purge_old_backups(&mut self, num_backups_to_keep: usize) -> Result<(), Error> {
   |  _____^ starting here...
69 | |         unsafe {
70 | |             ffi_try!(ffi::rocksdb_backup_engine_purge_old_backups(self.inner,
71 | |                                                                   num_backups_to_keep as uint32_t));
72 | |             Ok(())
73 | |         }
74 | |     }
   | |_____^ ...ending here

Those are now public.