### PR TITLE
Split 0.6.1 release note into its own section

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,12 @@ Changelog
 0.7 (in development)
 ~~~~~~~~~~~~~~~~~~~~
 
+0.6.1 (2017-03-13)
+~~~~~~~~~~~~~~~~~~
+
+**New features**
+ * Support for raw iterator access (kaedroho)
+
 0.6 (2016-12-18)
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -13,7 +19,6 @@ Changelog
  **New features**
  * Compaction filter (tmccombs)
  * Support for backups (alexreg)
- * Support for raw iterator access (kaedroho)
 
 0.5 (2016-11-20)
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Makes it clear to 0.6.0 users that they don't have this feature.