### PR TITLE
Fixed race condition in tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub struct BlockBasedOptions {
 /// use rocksdb::DBCompactionStyle;
 ///
 /// fn badly_tuned_for_somebody_elses_disk() -> DB {
-///    let path = "path/for/rocksdb/storage5";
+///    let path = "path/for/rocksdb/storageX";
 ///    let mut opts = Options::default();
 ///    opts.create_if_missing(true);
 ///    opts.set_max_open_files(10000);
@@ -150,7 +150,7 @@ pub struct Options {
 /// ```
 /// use rocksdb::{DB, WriteBatch, WriteOptions};
 ///
-/// let db = DB::open_default("path/for/rocksdb/storage6").unwrap();
+/// let db = DB::open_default("path/for/rocksdb/storageY").unwrap();
 ///
 /// let mut batch = WriteBatch::default();
 /// batch.put(b"my key", b"my value");


### PR DESCRIPTION
on my machine (osx 10.12.3) running tests very often fails with

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error { message: "IO error: lock path/for/rocksdb/storage6/LOCK: Resource temporarily unavailable" }', /Users/rustbuild/src/rust-buildbot/slave/stable-dist-rustc-mac/build/src/libcore/result.rs:868
stack backtrace:
```

This error is caused by race condition, cause tests in both `lib.rs` and `db.rs` are reusing database at the same location. This pr fixes that