### PR TITLE
Make it possible to pass in options to Column Families

### DIFF
--- a/tests/test_column_family.rs
+++ b/tests/test_column_family.rs
@@ -57,7 +57,7 @@ pub fn test_column_family() {
     {
         let mut opts = Options::default();
         opts.set_merge_operator("test operator", test_provided_merge);
-        match DB::open_cf(&opts, path, &["cf1"]) {
+        match DB::open_cf(&opts, path, &["cf1"], &[&opts]) {
             Ok(_) => println!("successfully opened db with column family"),
             Err(e) => panic!("failed to open db with column family: {}", e),
         }
@@ -70,7 +70,8 @@ pub fn test_column_family() {
     }
     // should b able to drop a cf
     {
-        let mut db = DB::open_cf(&Options::default(), path, &["cf1"]).unwrap();
+        let opts = Options::default();
+        let mut db = DB::open_cf(&Options::default(), path, &["cf1"], &[&opts]).unwrap();
         match db.drop_cf("cf1") {
             Ok(_) => println!("cf1 successfully dropped."),
             Err(e) => panic!("failed to drop column family: {}", e),
@@ -88,7 +89,7 @@ fn test_merge_operator() {
     {
         let mut opts = Options::default();
         opts.set_merge_operator("test operator", test_provided_merge);
-        let db = match DB::open_cf(&opts, path, &["cf1"]) {
+        let db = match DB::open_cf(&opts, path, &["cf1"], &[&opts]) {
             Ok(db) => {
                 println!("successfully opened db with column family");
                 db


### PR DESCRIPTION
So far Column Families were opened with the default options.
It is now possible to open them with custom options.

This commit is originally from the ngaut fork commit
07d44ea81909832b2f93de13a333131fd99469d7 [1]. It was
adapted to this code base.

[1]: https://github.com/ngaut/rust-rocksdb/commit/07d44ea81909832b2f93de13a333131fd99469d7

I'm sorry that I haven't pushed this a few days earlier before the version bump as this is a breaking change.