### PR TITLE
Remove `set_disable_data_sync`

### DIFF
--- a/librocksdb-sys/src/lib.rs
+++ b/librocksdb-sys/src/lib.rs
@@ -671,8 +671,6 @@ extern "C" {
     pub fn rocksdb_options_set_max_sequential_skip_in_iterations(opt: *mut rocksdb_options_t,
                                                                  v: uint64_t);
 
-    pub fn rocksdb_options_set_disable_data_sync(opt: *mut rocksdb_options_t, v: c_int);
-
     pub fn rocksdb_options_set_disable_auto_compactions(opt: *mut rocksdb_options_t, v: c_int);
 
     pub fn rocksdb_options_set_delete_obsolete_files_period_micros(opt: *mut rocksdb_options_t,

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -369,10 +369,6 @@ impl Options {
                                                                           allow as c_uchar) }
     }
 
-    pub fn set_disable_data_sync(&mut self, disable: bool) {
-        unsafe { ffi::rocksdb_options_set_disable_data_sync(self.inner, disable as c_int) }
-    }
-
     /// Enable direct I/O mode for reading
     /// they may or may not improve performance depending on the use case
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,6 @@ pub struct BlockBasedOptions {
 ///    opts.set_max_open_files(10000);
 ///    opts.set_use_fsync(false);
 ///    opts.set_bytes_per_sync(8388608);
-///    opts.set_disable_data_sync(false);
 ///    opts.optimize_for_point_lookup(1024);
 ///    opts.set_table_cache_num_shard_bits(6);
 ///    opts.set_max_write_buffer_number(32);


### PR DESCRIPTION
This is removed from rocksdb core as of facebook/rocksdb@eb912a9, and having the reference in the ffi causes loading the shared library to break.

The removal of this function is covered already by #133, but I figured I'd submit this separately in order to get things working for us until the build for that is fixed.