### PR TITLE
Preliminary: Allow creating iterators over prefixes

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -872,6 +872,12 @@ impl DB {
         DBIterator::new(self, &opts, mode)
     }
 
+    pub fn prefix_iterator<'a>(&self, prefix: &'a [u8]) -> DBIterator {
+        let mut opts = ReadOptions::default();
+        opts.set_prefix_same_as_start(true);
+        DBIterator::new(self, &opts, IteratorMode::From(prefix, Direction::Forward))
+    }
+
     pub fn iterator_cf(
         &self,
         cf_handle: ColumnFamily,
@@ -879,6 +885,16 @@ impl DB {
     ) -> Result<DBIterator, Error> {
         let opts = ReadOptions::default();
         DBIterator::new_cf(self, cf_handle, &opts, mode)
+    }
+
+    pub fn prefix_iterator_cf<'a>(
+        &self,
+        cf_handle: ColumnFamily,
+        prefix: &'a [u8]
+    ) -> Result<DBIterator, Error> {
+        let mut opts = ReadOptions::default();
+        opts.set_prefix_same_as_start(true);
+        DBIterator::new_cf(self, cf_handle, &opts, IteratorMode::From(prefix, Direction::Forward))
     }
 
     pub fn raw_iterator(&self) -> DBRawIterator {
@@ -1200,6 +1216,12 @@ impl ReadOptions {
                 key.as_ptr() as *const c_char,
                 key.len() as size_t,
             );
+        }
+    }
+
+    pub fn set_prefix_same_as_start(&mut self, v: bool) {
+        unsafe {
+            ffi::rocksdb_readoptions_set_prefix_same_as_start(self.inner, v as c_uchar)
         }
     }
 }


### PR DESCRIPTION
This is a proposal for an API that exposes the ability to limit (db or cf) iterators to key prefixes by using the `prefix_same_as_start` read option. It won't work at all until (or unless!) https://github.com/facebook/rocksdb/pull/3185 lands, but I figured I'd open it here to start discussion on the proposed API.

