### PR TITLE
Adding Send marker trait to Options...

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -30,6 +30,8 @@ pub fn new_cache(capacity: size_t) -> *mut ffi::rocksdb_cache_t {
     unsafe { ffi::rocksdb_cache_create_lru(capacity) }
 }
 
+unsafe impl Send for Options {}
+
 impl Drop for Options {
     fn drop(&mut self) {
         unsafe {


### PR DESCRIPTION
This PR is primarily motivated by a desire to be able to retrieve database statistics from multiple threads.

I couldn't find any documentation in RocksDb that indicates that `rocksdb_options_t` has any thread affinity. What documentation I did find [1] says that `rocksdb_t` is the only object that can be used without any synchronization (it's handled within).  All other objects must be have synchronization provided. 

By making the `Options` struct `Send` it would allow it to be used by multiple threads, so long as it is protected by some form of synchronization (eg. `Arc<Mutex<Options>>`).

1: https://github.com/facebook/rocksdb/wiki/Basic-Operations#concurrency