### PR TITLE
fixed a link error on windows

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -85,6 +85,8 @@ fn build_rocksdb() {
 
     if cfg!(windows) {
         link("rpcrt4", false);
+        link("shlwapi", true);
+
         config.define("OS_WIN", Some("1"));
 
         // Remove POSIX-specific sources


### PR DESCRIPTION
added shlwapi.lib to fix a IsRelativePathA() missing.

tested: Windows10 64bit MicrosoftVisualStudio2015/2017 with clang.lib-6.0
